### PR TITLE
Add SPDX support

### DIFF
--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -15,6 +15,7 @@ import sys
 from plumbum import local
 
 from libsbom import cyclonedx as alma_cyclonedx
+from libsbom import spdx as alma_spdx
 
 ALBS_URL = 'https://build.almalinux.org'
 SIGNER_ID = 'cloud-infra@almalinux.org'
@@ -49,7 +50,9 @@ class FileFormat:
     ] = 'cyclonedx'
     file_format: Literal[
         'json',
-        'xml'
+        'tagvalue',
+        'xml',
+        'yaml',
     ] = 'json'
 
     def __repr__(self):
@@ -62,6 +65,12 @@ class FileFormatType(object):
         'cyclonedx': [
             'json',
             'xml',
+        ],
+        'spdx': [
+            'json',
+            'tagvalue',
+            'xml',
+            'yaml',
         ]
     })
 
@@ -490,6 +499,10 @@ def create_parser():
 
 
 def cli_main():
+    formatters = {
+        'cyclonedx': alma_cyclonedx.SBOM,
+        'spdx':      alma_spdx.SBOM,
+    }
 
     args = create_parser().parse_args()
     signer_id = args.signer_id or SIGNER_ID
@@ -509,9 +522,7 @@ def cli_main():
         )
         sbom_object_type = 'package'
 
-    # TODO: For now we only support CycloneDX
-    # We should revisit this when adding SPDX
-    sbom_formatter = alma_cyclonedx.SBOM(
+    sbom_formatter = formatters[args.file_format.sbom_record_type](
         data=sbom,
         sbom_object_type=sbom_object_type,
         output_format=args.file_format.file_format,

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -4,7 +4,7 @@
 
 import argparse
 import json
-from typing import Dict, Tuple, Optional, Literal
+from typing import Dict, Tuple, Optional, Literal, List
 
 import dataclasses
 from collections import defaultdict
@@ -88,7 +88,7 @@ class FileFormatType(object):
         )
 
     @classmethod
-    def choices(cls) -> list[FileFormat]:
+    def choices(cls) -> List[FileFormat]:
         return [FileFormat(sbom_record_type, file_format) for
                 sbom_record_type in
                 cls.supported_file_formats for file_format in

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -301,7 +301,7 @@ def get_info_about_package(cas_hash: str, signer_id: str, albs_url: str):
                 'value': 'rpm',
             },
             {
-                'name': 'almalinux:sbom:cashHash',
+                'name': 'almalinux:sbom:casHash',
                 'value': cas_hash,
             },
             {
@@ -410,11 +410,11 @@ def get_info_about_build(build_id: int, signer_id: str, albs_url: str):
                         'value': cas_metadata['build_host'],
                     },
                     {
-                        'name': 'almalinux:abls:build:targetArch',
+                        'name': 'almalinux:albs:build:targetArch',
                         'value': cas_metadata['build_arch'],
                     },
                     {
-                        'name': 'almalinux:abls:build:packageType',
+                        'name': 'almalinux:albs:build:packageType',
                         'value': 'rpm',
                     },
                     {

--- a/libsbom/constants.py
+++ b/libsbom/constants.py
@@ -3,7 +3,7 @@ from version import __version__
 
 ALMAOS_VENDOR = 'AlmaLinux OS Foundation'
 ALMAOS_EMAIL = 'cloud-infra@almalinux.org'
-ALMAOS_SBOMLICENSE = 'CC0-1.0' # FIXME: Determine license for AlmaLinux SBOMs
+ALMAOS_SBOMLICENSE = 'CC0-1.0'
 ALMAOS_NAMESPACE = 'https://security.almalinux.org/spdx'
 
 TOOLS = [
@@ -27,6 +27,6 @@ TOOLS_SPDX = [
     {
         "vendor": ALMAOS_VENDOR,
         "name": "spdx-tools",
-        "version": "0.0" # FIXME: Need correct version info for spdx-tools
+        "version": "0.0"
     }
 ]

--- a/libsbom/constants.py
+++ b/libsbom/constants.py
@@ -27,6 +27,6 @@ TOOLS_SPDX = [
     {
         "vendor": ALMAOS_VENDOR,
         "name": "spdx-tools",
-        "version": "0.0"
+        "version": "0.8"
     }
 ]

--- a/libsbom/constants.py
+++ b/libsbom/constants.py
@@ -1,0 +1,32 @@
+from cas_wrapper import CasWrapper
+from version import __version__
+
+ALMAOS_VENDOR = 'AlmaLinux OS Foundation'
+ALMAOS_EMAIL = 'cloud-infra@almalinux.org'
+ALMAOS_SBOMLICENSE = 'CC0-1.0' # FIXME: Determine license for AlmaLinux SBOMs
+ALMAOS_NAMESPACE = 'https://security.almalinux.org/spdx'
+
+TOOLS = [
+    {
+        "vendor": ALMAOS_VENDOR,
+        "name": "AlmaLinux Build System",
+        "version": "0.1"  # Shall we start versioning ALBS?
+    },
+    {
+        "vendor": ALMAOS_VENDOR,
+        "name": "alma-sbom",
+        "version": __version__
+    },
+    {
+        "vendor": "Codenotary Inc",
+        "name": "Community Attestation Service (CAS)",
+        "version": CasWrapper.get_version()
+    }
+]
+TOOLS_SPDX = [
+    {
+        "vendor": ALMAOS_VENDOR,
+        "name": "spdx-tools",
+        "version": "0.0" # FIXME: Need correct version info for spdx-tools
+    }
+]

--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -11,26 +11,7 @@ from cyclonedx.output import OutputFormat, get_instance
 from packageurl import PackageURL
 from version import __version__
 
-ALMAOS_VENDOR = 'AlmaLinux OS Foundation'
-
-TOOLS = [
-    {
-        "vendor": ALMAOS_VENDOR,
-        "name": "AlmaLinux Build System",
-        "version": "0.1"  # Shall we start versioning ALBS?
-    },
-    {
-        "vendor": ALMAOS_VENDOR,
-        "name": "alma-sbom",
-        "version": __version__
-    },
-    {
-        "vendor": "Codenotary Inc",
-        "name": "Community Attestation Service (CAS)",
-        "version": CasWrapper.get_version()
-    }
-]
-
+from . import constants
 
 class SBOM:
     def __init__(self, data, sbom_object_type, output_format, output_file):
@@ -130,7 +111,7 @@ class SBOM:
         # in adding 'ersion: 1' to the final SBOM
 
         # We do this way to keep cyclonedx-python-lib as a tool
-        for tool in TOOLS:
+        for tool in constants.TOOLS:
             self._bom.metadata.tools.add(self.__generate_tool(tool))
 
         properties = [
@@ -157,7 +138,7 @@ class SBOM:
         # in adding 'ersion: 1' to the final SBOM
 
         # We do this way to keep cyclonedx-python-lib as a tool
-        for tool in TOOLS:
+        for tool in constants.TOOLS:
             self._bom.metadata.tools.add(self.__generate_tool(tool))
 
         self._bom.metadata.component = self.__generate_package_component(

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -181,7 +181,7 @@ class SBOM:
     def add_build(self, metadata):
         spdxid = self._document.creation_info.spdx_id
 
-        for prop in metadata:
+        for prop in metadata["properties"]:
             note = make_annotation(spdxid, f"{prop['name']}={prop['value']}")
             self._document.annotations += [note]
 

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -149,6 +149,9 @@ class SBOM:
         pkg = Package(spdx_id=pkgid,
                       name=component["name"],
                       download_location=SpdxNone())
+        rel = Relationship(spdx_element_id="SPDXRef-DOCUMENT",
+                           relationship_type=RelationshipType.DESCRIBES,
+                           related_spdx_element_id=pkgid)
 
         for pkghash in component["hashes"]:
             pkg.checksums += [make_checksum(pkghash["alg"],
@@ -166,6 +169,7 @@ class SBOM:
         pkg.files_analyzed = False
 
         self._document.packages += [pkg]
+        self._document.relationships += [rel]
 
         for prop in component["properties"]:
             note = make_annotation(pkgid, f"{prop['name']}={prop['value']}")

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -24,33 +24,8 @@ from spdx_tools.spdx.model import (
 )
 from spdx_tools.spdx.model.spdx_none import SpdxNone
 
-from cas_wrapper import CasWrapper
+from . import constants
 from version import __version__
-
-ALMAOS_VENDOR = 'AlmaLinux OS Foundation'
-ALMAOS_EMAIL = 'cloud-infra@almalinux.org'
-ALMAOS_SBOMLICENSE = 'CC0-1.0'                  # FIXME: Determine license for AlmaLinux SBOMs
-ALMAOS_NAMESPACE = 'https://security.almalinux.org/spdx'
-
-TOOLS = [
-    {
-        "vendor": ALMAOS_VENDOR,
-        "name": "AlmaLinux Build System",
-        "version": "0.1"
-    }, {
-        "vendor": ALMAOS_VENDOR,
-        "name": "alma-sbom",
-        "version": __version__
-    }, {
-        "vendor": ALMAOS_VENDOR,
-        "name": "spdx-tools",
-        "version": "0.0" # FIXME: Need correct version info for spdx-tools
-    }, {
-        "vendor": "Codenotary Inc",
-        "name": "Community Attestation Service (CAS)",
-        "version": CasWrapper.get_version()
-    }
-]
 
 writers = {
     'json':     json_writer,
@@ -120,16 +95,17 @@ def build_get_timestamp(build: dict) -> datetime.datetime:
 
 class SBOM:
     def __init__(self, data, sbom_object_type, output_format, output_file):
+        tools = constants.TOOLS + constants.TOOLS_SPDX
         self._input_data = data
         self._sbom_object_type = sbom_object_type
         self._output_format = output_format
         self._output_file = output_file
 
         self._org = Actor(ActorType.ORGANIZATION,
-                          ALMAOS_VENDOR,
-                          ALMAOS_EMAIL)
+                          constants.ALMAOS_VENDOR,
+                          constants.ALMAOS_EMAIL)
         self._creators = [self._org] + [Actor(actor_type=ActorType.TOOL,
-                                              name=f"{tool['name']} {tool['version']}") for tool in TOOLS]
+                                              name=f"{tool['name']} {tool['version']}") for tool in tools]
 
         self._document = None
         self._next_id = 0
@@ -159,8 +135,8 @@ class SBOM:
         doc_info = CreationInfo(spdx_version="SPDX-2.3",
                                 spdx_id=f"SPDXRef-{doc_uuid}",
                                 name=doc_name,
-                                data_license=ALMAOS_SBOMLICENSE,
-                                document_namespace=f"{ALMAOS_NAMESPACE}-{doc_name}-{doc_uuid}",
+                                data_license=constants.ALMAOS_SBOMLICENSE,
+                                document_namespace=f"{constants.ALMAOS_NAMESPACE}-{doc_name}-{doc_uuid}",
                                 creators=self._creators,
                                 created=datetime.datetime.now())
 

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -133,7 +133,7 @@ class SBOM:
 
         doc_uuid = uuid.uuid4()
         doc_info = CreationInfo(spdx_version="SPDX-2.3",
-                                spdx_id=f"SPDXRef-{doc_uuid}",
+                                spdx_id="SPDXRef-DOCUMENT",
                                 name=doc_name,
                                 data_license=constants.ALMAOS_SBOMLICENSE,
                                 document_namespace=f"{constants.ALMAOS_NAMESPACE}-{doc_name}-{doc_uuid}",

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -18,7 +18,6 @@ from spdx_tools.spdx.model import (
     ExternalPackageRef,
     ExternalPackageRefCategory,
     Package,
-    PackagePurpose,
     Relationship,
     RelationshipType
 )

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -22,6 +22,7 @@ from spdx_tools.spdx.model import (
     Relationship,
     RelationshipType
 )
+from spdx_tools.spdx.model.spdx_none import SpdxNone
 
 from cas_wrapper import CasWrapper
 from version import __version__
@@ -157,7 +158,7 @@ class SBOM:
 
         pkg = Package(spdx_id=pkgid,
                       name=component["name"],
-                      download_location=component["purl"]) # FIXME: download_location must point to the RPM on a mirror
+                      download_location=SpdxNone())
 
         for pkghash in component["hashes"]:
             pkg.checksums += [make_checksum(pkghash["alg"],

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -73,12 +73,22 @@ def make_checksum(algo: str, value: str) -> Checksum:
     return Checksum(algo_map[algo], value)
 
 
+def buildtime_to_datetime(buildtime: str) -> datetime.datetime:
+    """Parse buildtime without nanoseconds into a datetime object.
+
+    The build timestamp is stored in nanosecond-precision in CAS, but
+    datetime.fromisoformat() on Python 3.10 or older is unable to parse
+    timestamps with sub-microsecond precision.
+    """
+    return datetime.datetime.fromisoformat(buildtime[:-4])
+
+
 def component_get_buildtime(component: dict) -> datetime.datetime:
     buildtime = component_get_property(component, "almalinux:package:timestamp")
 
     # Components in build SBOMs do not have timestamps
     try:
-        return datetime.datetime.fromisoformat(buildtime)
+        return buildtime_to_datetime(buildtime)
     except TypeError:
         return None
 
@@ -87,6 +97,7 @@ def build_get_timestamp(build: dict) -> datetime.datetime:
     buildtime = component_get_property(build, "almalinux:albs:build:timestamp")
 
     try:
+        # build timestamps don't have nanosecond-precision, no need for buildtime_to_datetime()
         return datetime.datetime.fromisoformat(buildtime)
     except TypeError:
         return None

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -1,0 +1,213 @@
+import logging
+import datetime
+import uuid
+
+from spdx_tools.spdx.writer.json     import json_writer
+from spdx_tools.spdx.writer.tagvalue import tagvalue_writer
+from spdx_tools.spdx.writer.xml      import xml_writer
+from spdx_tools.spdx.writer.yaml     import yaml_writer
+from spdx_tools.spdx.model import (
+    Actor,
+    ActorType,
+    Annotation,
+    AnnotationType,
+    Checksum,
+    ChecksumAlgorithm,
+    CreationInfo,
+    Document,
+    ExternalPackageRef,
+    ExternalPackageRefCategory,
+    Package,
+    PackagePurpose,
+    Relationship,
+    RelationshipType
+)
+
+from cas_wrapper import CasWrapper
+from version import __version__
+
+ALMAOS_VENDOR = 'AlmaLinux OS Foundation'
+ALMAOS_EMAIL = 'cloud-infra@almalinux.org'
+ALMAOS_SBOMLICENSE = 'CC0-1.0'                  # FIXME: Determine license for AlmaLinux SBOMs
+ALMAOS_NAMESPACE = 'https://security.almalinux.org/spdx'
+
+TOOLS = [
+    {
+        "vendor": ALMAOS_VENDOR,
+        "name": "AlmaLinux Build System",
+        "version": "0.1"
+    }, {
+        "vendor": ALMAOS_VENDOR,
+        "name": "alma-sbom",
+        "version": __version__
+    }, {
+        "vendor": ALMAOS_VENDOR,
+        "name": "spdx-tools",
+        "version": "0.0" # FIXME: Need correct version info for spdx-tools
+    }, {
+        "vendor": "Codenotary Inc",
+        "name": "Community Attestation Service (CAS)",
+        "version": CasWrapper.get_version()
+    }
+]
+
+writers = {
+    'json':     json_writer,
+    'tagvalue': tagvalue_writer,
+    'xml':      xml_writer,
+    'yaml':     yaml_writer,
+}
+
+def component_get_property(component: dict, property_name: str) -> str:
+    for prop in component["properties"]:
+        if prop["name"] == property_name:
+            return prop["value"]
+
+    return None
+
+
+def make_cpe_ref(cpe: str) -> ExternalPackageRef:
+    return ExternalPackageRef(ExternalPackageRefCategory.SECURITY,
+                              "cpe23Type", cpe)
+
+
+def make_purl_ref(purl: str) -> ExternalPackageRef:
+    return ExternalPackageRef(ExternalPackageRefCategory.PACKAGE_MANAGER,
+                              "purl", purl)
+
+
+def make_annotation(spdxid: str, content: str) -> Annotation:
+    this_tool = Actor(actor_type=ActorType.TOOL,
+                      name=f"alma-sbom {__version__}")
+
+    return Annotation(spdx_id=spdxid,
+                      annotation_type=AnnotationType.OTHER,
+                      annotator=this_tool,
+                      annotation_date=datetime.datetime.now(),
+                      annotation_comment=content)
+
+
+def make_checksum(algo: str, value: str) -> Checksum:
+    algo_map = {
+        "SHA-256": ChecksumAlgorithm.SHA256
+    }
+
+    if not algo in algo_map:
+        raise ValueError(f"Algorithm {algo} is not supported")
+
+    return Checksum(algo_map[algo], value)
+
+
+def component_get_buildtime(component: dict) -> datetime.datetime:
+    buildtime = component_get_property(component, "almalinux:package:timestamp")
+    return datetime.datetime.fromisoformat(buildtime)
+
+
+class SBOM:
+    def __init__(self, data, sbom_object_type, output_format, output_file):
+        self._input_data = data
+        self._sbom_object_type = sbom_object_type
+        self._output_format = output_format
+        self._output_file = output_file
+
+        self._org = Actor(ActorType.ORGANIZATION,
+                          ALMAOS_VENDOR,
+                          ALMAOS_EMAIL)
+        self._creators = [self._org]
+
+        for tool in TOOLS:
+            self._creators += [Actor(actor_type=ActorType.TOOL,
+                                     name=f"{tool['name']} {tool['version']}")]
+
+        self._document = None
+        self._next_id = 0
+        self._prepare_document()
+
+
+    def get_next_package_id(self) -> str:
+        """Return an identifier that can be assigned to a package in this document.
+
+        Further reading:
+        https://spdx.github.io/spdx-spec/v2-draft/package-information/#72-package-spdx-identifier-field
+        """
+        cur_id = self._next_id
+        self._next_id += 1
+        return f"SPDXRef-{cur_id}"
+
+
+    def _prepare_document(self):
+        if "metadata" in self._input_data:
+            doc_name = self._input_data["metadata"]["name"]
+        else:
+            pkgname = self._input_data['component']['name']
+            pkgvers = self._input_data['component']['version']
+            doc_name = f"{pkgname}-{pkgvers}"
+
+        doc_info = CreationInfo(spdx_version="SPDX-2.3",
+                                spdx_id=f"SPDXRef-{uuid.uuid4()}",
+                                name=doc_name,
+                                data_license=ALMAOS_SBOMLICENSE,
+                                document_namespace=ALMAOS_NAMESPACE,
+                                creators=self._creators,
+                                created=datetime.datetime.now())
+
+        self._document = Document(doc_info)
+
+
+    def add_package(self, component):
+        pkgid = self.get_next_package_id()
+
+        pkg = Package(spdx_id=pkgid,
+                      name=component["name"],
+                      download_location=component["purl"]) # FIXME: download_location must point to the RPM on a mirror
+
+        for pkghash in component["hashes"]:
+            pkg.checksums += [make_checksum(pkghash["alg"],
+                                            pkghash["content"])]
+
+        pkg.version = component["version"]
+        pkg.supplier = self._org
+        pkg.external_references += [make_cpe_ref(component["cpe"]),
+                                    make_purl_ref(component["purl"])]
+        pkg.built_date = component_get_buildtime(component)
+        pkg.files_analyzed = False
+
+        self._document.packages += [pkg]
+
+        for prop in component["properties"]:
+            note = make_annotation(pkgid, f"{prop['name']}={prop['value']}")
+            self._document.annotations += [note]
+
+
+    def add_build(self, metadata):
+        spdxid = self._document.creation_info.spdx_id
+
+        for prop in metadata:
+            note = make_annotation(spdxid, f"{prop['name']}={prop['value']}")
+            self._document.annotations += [note]
+
+
+    def _generate(self):
+        components = []
+
+        # There is either a single package in "component" or multiple packages in "components"
+        if "component" in self._input_data:
+            components += [self._input_data["component"]]
+        if "components" in self._input_data:
+            components += self._input_data["components"]
+
+        for component in components:
+            self.add_package(component)
+
+        # build SBOMs also contain build metadata
+        if "metadata" in self._input_data:
+            self.add_build(self._input_data["metadata"])
+
+
+    def run(self):
+        writer = writers[self._output_format]
+
+        self._generate()
+        writer.write_document_to_file(self._document,
+                                      self._output_file or "/dev/stdout",
+                                      validate=False)

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -204,4 +204,4 @@ class SBOM:
         self._generate()
         writer.write_document_to_file(self._document,
                                       self._output_file or "/dev/stdout",
-                                      validate=False)
+                                      validate=True)

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -113,11 +113,8 @@ class SBOM:
         self._org = Actor(ActorType.ORGANIZATION,
                           ALMAOS_VENDOR,
                           ALMAOS_EMAIL)
-        self._creators = [self._org]
-
-        for tool in TOOLS:
-            self._creators += [Actor(actor_type=ActorType.TOOL,
-                                     name=f"{tool['name']} {tool['version']}")]
+        self._creators = [self._org] + [Actor(actor_type=ActorType.TOOL,
+                                              name=f"{tool['name']} {tool['version']}") for tool in TOOLS]
 
         self._document = None
         self._next_id = 0

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -140,11 +140,12 @@ class SBOM:
             pkgvers = self._input_data['component']['version']
             doc_name = f"{pkgname}-{pkgvers}"
 
+        doc_uuid = uuid.uuid4()
         doc_info = CreationInfo(spdx_version="SPDX-2.3",
-                                spdx_id=f"SPDXRef-{uuid.uuid4()}",
+                                spdx_id=f"SPDXRef-{doc_uuid}",
                                 name=doc_name,
                                 data_license=ALMAOS_SBOMLICENSE,
-                                document_namespace=ALMAOS_NAMESPACE,
+                                document_namespace=f"{ALMAOS_NAMESPACE}-{doc_name}-{doc_uuid}",
                                 creators=self._creators,
                                 created=datetime.datetime.now())
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
         'requests>=2.20.0',
         'dataclasses>=0.8',
         'cyclonedx-python-lib==2.7.1',
-        'spdx-tools>0.7.1',
+        'spdx-tools==0.8',
         'packageurl-python==0.10.3',
         'GitPython==3.1.29',
         'cas_wrapper'

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'requests>=2.20.0',
         'dataclasses>=0.8',
         'cyclonedx-python-lib==2.7.1',
+        'spdx-tools>0.7.1',
         'packageurl-python==0.10.3',
         'GitPython==3.1.29',
         'cas_wrapper'


### PR DESCRIPTION
This commit adds an SPDX module to libsbom and modifies alma_sbom.py
so that it can output SBOMs in SPDX format.
This further adds support for yaml and tagvalue output if SPDX is
selected as the output format.