### PR TITLE
libsbom: Normalize epochs in package versions

### DIFF
--- a/libsbom/common.py
+++ b/libsbom/common.py
@@ -1,0 +1,56 @@
+import typing
+
+def replace_patterns(input_str: str, patterns: typing.Dict[str, str]) -> str:
+    """Convenience function to perform multiple string replacements."""
+
+    output_str = input_str
+
+    for search, replace in patterns.items():
+        output_str = output_str.replace(search, replace)
+
+    return output_str
+
+
+def normalize_epoch_in_version(version: str) -> str:
+    """Replace unset epochs in version strings with 0."""
+
+    patterns = {
+        'None:':   '0:',
+        '(none):': '0:',
+    }
+
+    return replace_patterns(input_str=version,
+                            patterns=patterns)
+
+
+def normalize_epoch_in_purl(purl: str) -> str:
+    """Replace unset epochs in PURLs with 0."""
+
+    patterns = {
+        'epoch=None':   'epoch=0',
+        'epoch=(none)': 'epoch=0',
+    }
+
+    return replace_patterns(input_str=purl,
+                            patterns=patterns)
+
+
+def normalize_epoch_in_cpe(cpe: str) -> str:
+    """Replace unset epochs in CPEs with 0."""
+
+    patterns = {
+        ':None\\:':   ':0\\:',
+        ':(none)\\:': ':0\\:',
+    }
+
+    return replace_patterns(input_str=cpe,
+                            patterns=patterns)
+
+
+def normalize_epoch_in_prop(name: str, value: str) -> str:
+    """Replace unset epochs in propertiy strings with 0."""
+
+    if name != 'almalinux:package:epoch':
+        return value
+
+    return value.replace('None', '0').replace('(none)', '0')

--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -11,6 +11,7 @@ from packageurl import PackageURL
 from version import __version__
 
 from . import constants
+from . import common
 
 
 class SBOM:
@@ -71,7 +72,8 @@ class SBOM:
         # https://cyclonedx.org/docs/1.4/json/#components_items_properties_items_value
         return Property(
             name=prop['name'],
-            value=str(prop['value']),
+            value=common.normalize_epoch_in_prop(prop['name'],
+                                                 str(prop['value'])),
         )
 
     @staticmethod
@@ -82,14 +84,15 @@ class SBOM:
         )
 
     def __generate_package_component(self, comp):
+        purl = common.normalize_epoch_in_purl(comp['purl'])
         return Component(
             component_type=ComponentType('library'),
             name=comp['name'],
-            version=comp['version'],
+            version=common.normalize_epoch_in_version(str(comp['version'])),
             publisher='AlmaLinux',
             hashes=[self.__generate_hash(h) for h in comp['hashes']],
-            cpe=comp['cpe'],
-            purl=PackageURL.from_string(comp['purl']),
+            cpe=common.normalize_epoch_in_cpe(comp['cpe']),
+            purl=PackageURL.from_string(purl),
             properties=[
                 self.__generate_prop(prop) for prop in comp['properties']
             ],


### PR DESCRIPTION
When a package's epoch is not set, alma-sbom generates SBOMs with the package's version set to something like "None:1.0". Since the epoch has to be an unsigned integer (if it is present at all), this might confuse tools that are consuming SBOM data. According to the RPM spec, a missing epoch is equivalent to 0, so this is what should be in the SBOM.

This commit modifies the SPDX and CycloneDX SBOM generators so that missing epochs will be normalized to 0.