### PR TITLE
libsbom: Use same vendor name in both SBOM formats

### DIFF
--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -86,7 +86,7 @@ class SBOM:
             component_type=ComponentType('library'),
             name=comp['name'],
             version=comp['version'],
-            publisher='AlmaLinux',
+            publisher=constants.ALMAOS_VENDOR,
             hashes=[self.__generate_hash(h) for h in comp['hashes']],
             cpe=comp['cpe'],
             purl=PackageURL.from_string(comp['purl']),


### PR DESCRIPTION
When generating SBOMs in CycloneDX format, alma-sbom uses a hardcoded vendor name instead of the name in the constants module. Thus, SBOMs in CycloneDX format have a different vendor than those in SPDX format.

This commit modifies the CycloneDX SBOM generation so it uses the vendor name from the constants module instead of a hardcoded value.