### PR TITLE
Refactor input_data structure

### DIFF
--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -256,7 +256,8 @@ def get_info_about_package(
     result['version'] = 1
     if 'unsigned_hash' in immudb_metadata:
         result['version'] += 1
-    result['component'] = {
+    result['metadata'] = {}
+    result['metadata']['component'] = {
         'name': package_nevra.name,
         'version': (
             f'{package_nevra.epoch if package_nevra.epoch else ""}'
@@ -332,7 +333,7 @@ def get_info_about_package(
 
     add_package_source_info(
         immudb_metadata=immudb_metadata,
-        component=result['component'],
+        component=result['metadata']['component'],
     )
     return result
 
@@ -370,7 +371,8 @@ def get_info_about_build(
             },
         ],
     }
-    result['metadata'] = build_metadata
+    result['metadata'] = {}
+    result['metadata']['component'] = build_metadata
     components = []
     for task in json_data['tasks']:
         for artifact in task['artifacts']:

--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -99,7 +99,7 @@ class SBOM:
         )
 
     def generate_build_sbom(self):
-        input_metadata = self.input_data['metadata']
+        input_metadata = self.input_data['metadata']['component']
         input_components = self.input_data['components']
 
         # TODO: Figure out how to set the SBOM version, because
@@ -137,5 +137,5 @@ class SBOM:
             self._bom.metadata.tools.add(self.__generate_tool(tool))
 
         self._bom.metadata.component = self.__generate_package_component(
-            self.input_data['component'],
+            self.input_data['metadata']['component'],
         )

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -152,11 +152,12 @@ class SBOM:
         return f"SPDXRef-{cur_id}"
 
     def _prepare_document(self):
-        if "metadata" in self._input_data:
-            doc_name = self._input_data["metadata"]["name"]
-        else:
-            pkgname = self._input_data['component']['name']
-            pkgvers = self._input_data['component']['version']
+        metadata = self._input_data["metadata"]['component']
+        if self._sbom_object_type == 'build':
+            doc_name = metadata["name"]
+        else: # self._sbom_object_type == 'package':
+            pkgname = metadata['name']
+            pkgvers = metadata['version']
             pkgvers = common.normalize_epoch_in_version(pkgvers)
             doc_name = f"{pkgname}-{pkgvers}"
 
@@ -227,24 +228,20 @@ class SBOM:
 
     def _generate(self):
         components = []
-        build_data = (
-            self._input_data["metadata"]
-            if "metadata" in self._input_data
-            else {}
-        )
 
-        # There is either a single package in "component" or multiple packages in "components"
-        if "component" in self._input_data:
-            components += [self._input_data["component"]]
-        if "components" in self._input_data:
+        # packages data are in "components" if sbom_object_type = 'build'
+        # package data is in "metadata"."component" if sbom_object_type = 'package'
+        # build SBOMs also contain build metadata
+        if self._sbom_object_type == 'build':
+            build_data = self._input_data["metadata"]["component"]
+            self.add_build(build_data)
             components += self._input_data["components"]
+        else: # self._sbom_object_type == 'package':
+            build_data = {}
+            components += [self._input_data["metadata"]["component"]]
 
         for component in components:
             self.add_package(component, build_data)
-
-        # build SBOMs also contain build metadata
-        if build_data:
-            self.add_build(build_data)
 
     def run(self):
         writer = writers[self._output_format]


### PR DESCRIPTION
The information generated by get_info_about_build() and get_info_about_package() is structured similarly to the CycloneDX data model. However, the way information is used in the metadata field was different from that of CycloneDX.
This patch fixed that.
This change will be useful when adding information to the metadata field in the future.

In addition, I have slightly changed the way SBOMs are created in libsbom/spdx.py to use the sbom_object_type.