### PR TITLE
Create and configure the logger

### DIFF
--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -1,6 +1,6 @@
 import json
-import logging
 import xml.dom.minidom
+from logging import getLogger
 
 from cyclonedx.model import HashAlgorithm, HashType, Property
 from cyclonedx.model.bom import Bom, Tool
@@ -12,6 +12,8 @@ from version import __version__
 
 from . import constants
 from . import common
+
+_logger = getLogger('alma-sbom')
 
 
 class SBOM:
@@ -54,7 +56,7 @@ class SBOM:
         if self.output_file:
             with open(self.output_file, 'w') as fd:
                 fd.write(pretty_output)
-            logging.info('Wrote generated SBOM to %s', self.output_file)
+            _logger.info('Wrote generated SBOM to %s', self.output_file)
         else:
             print(pretty_output)
 

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -1,6 +1,7 @@
 import datetime
 import uuid
 from typing import Optional, Union
+from logging import getLogger
 
 from spdx_tools.spdx.model import (
     Actor,
@@ -34,6 +35,8 @@ writers = {
     'xml': xml_writer,
     'yaml': yaml_writer,
 }
+
+_logger = getLogger('alma-sbom')
 
 
 def component_get_property(
@@ -255,3 +258,5 @@ class SBOM:
             self._output_file or "/dev/stdout",
             validate=True,
         )
+        if self._output_file:
+            _logger.info('Wrote generated SBOM to %s', self._output_file)


### PR DESCRIPTION
solved #6 

This commit makes the following changes:
 - Create logger named 'alma-sbom' and format logs to include the name
 - Add two options related log levels (--debug, --verbose)

Now, we can get the following output using --verbose option.
```
(env) $ python alma_sbom.py --verbose --file-format spdx-json --rpm-package-hash 449253dc6197374682b579374b9ff3afda6d3fda38107a6187c00564cae20354 --output-file /tmp/test.spdx.json
Feb 29 17:19:52 alma-sbom: [INFO] Wrote generated SBOM to /tmp/test.spdx.json
```