### PR TITLE
Change dependencies installation to use `pip install .`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ These utilities consist in:
 
 1. Create a Python Virtual Environment: `python3.9 -m venv env`
 2. Activate the Virtual Environment: `source env/bin/activate`
-3. Install dependencies: `python setup.py install`
+3. Install dependencies: `pip install .`
 
 ## Using the AlmaLinux SBOM CLI
 

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,7 @@ setup(
         'urllib3<2.0',
         'packageurl-python==0.10.3',
         'GitPython==3.1.29',
-        'immudb_wrapper',
-    ],
-    dependency_links=[
-        'git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.4#egg=immudb_wrapper'
+        'immudb_wrapper @ git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.4#egg=immudb_wrapper',
     ],
     python_requires=">=3.9",
 )


### PR DESCRIPTION
The dependencies installation using `setup.py install` is deprecated and may fail in the future.
Change dependencies notation because it seems that `dependency_links` is not evaluated with `pip install`.

solved #35 