### PR TITLE
Add --rpm-package option

### DIFF
--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -116,10 +116,17 @@ def generate_sbom_version(json_data: Dict) -> int:
 
 
 def _extract_immudb_info_about_package(
-    immudb_hash: str,
     immudb_wrapper: ImmudbWrapper,
+    immudb_hash: str = None,
+    rpm_package: str = None,
 ) -> Dict:
-    response = immudb_wrapper.authenticate(immudb_hash)
+    if immudb_hash != None :
+        response = immudb_wrapper.authenticate(immudb_hash)
+    elif rpm_package != None :
+        if not os.path.exists(rpm_package):
+            logging.error(f'File {rpm_package} Not Found')
+            sys.exit(1)
+        response = immudb_wrapper.authenticate_file(rpm_package)
     result = response.get('value', {})
     result['timestamp'] = response.get('timestamp')
     return result
@@ -240,18 +247,21 @@ def add_package_source_info(immudb_metadata: Dict, component: Dict):
 
 
 def get_info_about_package(
-    immudb_hash: str,
     albs_url: str,
     immudb_wrapper: ImmudbWrapper,
+    immudb_hash: str = None,
+    rpm_package: str = None,
 ):
     result = {}
     immudb_info_about_package = _extract_immudb_info_about_package(
-        immudb_hash=immudb_hash,
         immudb_wrapper=immudb_wrapper,
+        immudb_hash=immudb_hash,
+        rpm_package=rpm_package,
     )
     source_rpm, package_nevra = _get_specific_info_about_package(
         immudb_info_about_package=immudb_info_about_package,
     )
+    immudb_hash = immudb_hash or immudb_info_about_package['Hash']
     immudb_metadata = immudb_info_about_package['Metadata']
     result['version'] = 1
     if 'unsigned_hash' in immudb_metadata:
@@ -380,8 +390,8 @@ def get_info_about_build(
                 continue
             immudb_hash = artifact['cas_hash']
             result_of_execution = _extract_immudb_info_about_package(
-                immudb_hash=immudb_hash,
                 immudb_wrapper=immudb_wrapper,
+                immudb_hash=immudb_hash,
             )
             immudb_metadata = result_of_execution['Metadata']
             source_rpm, package_nevra = _get_specific_info_about_package(
@@ -514,6 +524,11 @@ def create_parser():
         '--rpm-package-hash',
         type=str,
         help='SHA256 hash of an RPM package',
+    )
+    object_id_group.add_argument(
+        '--rpm-package',
+        type=str,
+        help='path to an RPM package',
     )
     parser.add_argument(
         '--albs-url',
@@ -685,9 +700,10 @@ def cli_main():
         sbom_object_type = 'build'
     else:
         sbom = get_info_about_package(
-            args.rpm_package_hash,
             albs_url=albs_url,
             immudb_wrapper=immudb_wrapper,
+            immudb_hash=args.rpm_package_hash,
+            rpm_package=args.rpm_package,
         )
         sbom_object_type = 'package'
     opt_creators = _proc_opt_creators(

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -124,7 +124,7 @@ def _extract_immudb_info_about_package(
         response = immudb_wrapper.authenticate(immudb_hash)
     elif rpm_package != None :
         if not os.path.exists(rpm_package):
-            logging.error(f'File {rpm_package} Not Found')
+            _logger.error(f'File {rpm_package} Not Found')
             sys.exit(1)
         response = immudb_wrapper.authenticate_file(rpm_package)
     result = response.get('value', {})


### PR DESCRIPTION
This patch allows users to create a package SBOM by specifying the RPM package itself without having to calculate a hash value.
This also allows the SBOM field to be extended since the package information can be referenced within alma_sbom.