### PR TITLE
Add licenses and description fields when using --rpm-package option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ These utilities consist in:
 * packageurl-python >= 0.10.3
 * GitPython == 3.1.29
 * immudb_wrapper >= 0.1.4
+* rpm >= 4.14 (or rpm == 0.3.1 in venv)
 
 ## Getting started
 

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -116,10 +116,17 @@ def generate_sbom_version(json_data: Dict) -> int:
 
 
 def _extract_immudb_info_about_package(
-    immudb_hash: str,
     immudb_wrapper: ImmudbWrapper,
+    immudb_hash: str = None,
+    rpm_package: str = None,
 ) -> Dict:
-    response = immudb_wrapper.authenticate(immudb_hash)
+    if immudb_hash != None :
+        response = immudb_wrapper.authenticate(immudb_hash)
+    elif rpm_package != None :
+        if not os.path.exists(rpm_package):
+            logging.error(f'File {rpm_package} Not Found')
+            sys.exit(1)
+        response = immudb_wrapper.authenticate_file(rpm_package)
     result = response.get('value', {})
     result['timestamp'] = response.get('timestamp')
     return result
@@ -240,18 +247,21 @@ def add_package_source_info(immudb_metadata: Dict, component: Dict):
 
 
 def get_info_about_package(
-    immudb_hash: str,
     albs_url: str,
     immudb_wrapper: ImmudbWrapper,
+    immudb_hash: str = None,
+    rpm_package: str = None,
 ):
     result = {}
     immudb_info_about_package = _extract_immudb_info_about_package(
-        immudb_hash=immudb_hash,
         immudb_wrapper=immudb_wrapper,
+        immudb_hash=immudb_hash,
+        rpm_package=rpm_package,
     )
     source_rpm, package_nevra = _get_specific_info_about_package(
         immudb_info_about_package=immudb_info_about_package,
     )
+    immudb_hash = immudb_hash or immudb_info_about_package['Hash']
     immudb_metadata = immudb_info_about_package['Metadata']
     result['version'] = 1
     if 'unsigned_hash' in immudb_metadata:
@@ -380,8 +390,8 @@ def get_info_about_build(
                 continue
             immudb_hash = artifact['cas_hash']
             result_of_execution = _extract_immudb_info_about_package(
-                immudb_hash=immudb_hash,
                 immudb_wrapper=immudb_wrapper,
+                immudb_hash=immudb_hash,
             )
             immudb_metadata = result_of_execution['Metadata']
             source_rpm, package_nevra = _get_specific_info_about_package(
@@ -514,6 +524,11 @@ def create_parser():
         '--rpm-package-hash',
         type=str,
         help='SHA256 hash of an RPM package',
+    )
+    object_id_group.add_argument(
+        '--rpm-package',
+        type=str,
+        help='path to an RPM package',
     )
     parser.add_argument(
         '--albs-url',
@@ -685,9 +700,10 @@ def cli_main():
         sbom_object_type = 'build'
     else:
         sbom = get_info_about_package(
-            args.rpm_package_hash,
             albs_url=albs_url,
             immudb_wrapper=immudb_wrapper,
+            immudb_hash=args.rpm_package_hash,
+            rpm_package=args.rpm_package,
         )
         sbom_object_type = 'package'
     opt_creators = _proc_opt_creators(

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -270,24 +270,14 @@ def add_rpm_package_info(
         return
     ts = rpm.TransactionSet()
     try:
-        fd = os.open(rpm_package, os.O_RDONLY)
-        hdr = ts.hdrFromFdno(fd)
-    except OSError as e:
-        _logger.error(f'file open error: {e.strerror}')
-        sys.exit(1)
-    except rpm.error as e:
+        with open(rpm_package) as fd:
+            hdr = ts.hdrFromFdno(fd)
+    except (OSError, rpm.error) as e:
         _logger.error(f'file open error: {str(e)}')
         sys.exit(1)
     except Exception as e:
         _logger.error(f'unknown error: {str(e)}')
         sys.exit(1)
-    else:
-        pass
-    finally:
-        try:
-            os.close(fd)
-        except Exception:
-            pass
 
     component['licenses'] = _proc_licenses(hdr[rpm.RPMTAG_LICENSE])
     component['summary'] = hdr[rpm.RPMTAG_SUMMARY]

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -124,7 +124,7 @@ def _extract_immudb_info_about_package(
         response = immudb_wrapper.authenticate(immudb_hash)
     elif rpm_package != None :
         if not os.path.exists(rpm_package):
-            logging.error(f'File {rpm_package} Not Found')
+            _logger.error(f'File {rpm_package} Not Found')
             sys.exit(1)
         response = immudb_wrapper.authenticate_file(rpm_package)
     result = response.get('value', {})

--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -2,7 +2,7 @@ import json
 import xml.dom.minidom
 from logging import getLogger
 
-from cyclonedx.model import HashAlgorithm, HashType, Property, OrganizationalContact
+from cyclonedx.model import HashAlgorithm, HashType, Property, OrganizationalContact, LicenseChoice
 from cyclonedx.model.bom import Bom, Tool
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.output import OutputFormat, get_instance
@@ -86,6 +86,17 @@ class SBOM:
             hash_value=hash_['content'],
         )
 
+    @staticmethod
+    def __generate_licenses(_license):
+        l = []
+        if 'ids' in _license and _license['ids']:
+            for lid in _license['ids']:
+                l.append( LicenseChoice(license_=lid) )
+
+        elif 'expression' in _license and _license['expression']:
+            l.append( LicenseChoice(license_expression=_license['expression']) )
+        return l
+
     def __add_authors(self, authors):
         if authors != None:
             d = len(authors['name']) - len(authors['email'])
@@ -121,6 +132,9 @@ class SBOM:
             properties=[
                 self.__generate_prop(prop) for prop in comp['properties']
             ],
+            licenses=self.__generate_licenses(comp['licenses'])
+                if 'licenses' in comp and comp['licenses'] else [] ,
+            description=comp['description']
         )
 
     def generate_build_sbom(self):

--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -133,8 +133,9 @@ class SBOM:
                 self.__generate_prop(prop) for prop in comp['properties']
             ],
             licenses=self.__generate_licenses(comp['licenses'])
-                if 'licenses' in comp and comp['licenses'] else [] ,
+                if 'licenses' in comp and comp['licenses'] else None ,
             description=comp['description']
+                if 'description' in comp and comp['description'] else None ,
         )
 
     def generate_build_sbom(self):

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 from typing import Optional, Union
 from logging import getLogger
+from license_expression import Licensing, ExpressionError
 
 from spdx_tools.spdx.model import (
     Actor,
@@ -233,6 +234,28 @@ class SBOM:
             raise ValueError(f"Cannot determine build time of {pkg.name}")
 
         pkg.files_analyzed = False
+
+        if 'licenses' in component and component['licenses']:
+            pkg.license_concluded = SpdxNoAssertion()
+            if 'expression' in component['licenses'] and component['licenses']['expression']:
+                pkg.license_comment = component['licenses']['expression']
+
+        ### NOTE
+        ### license_info_frpm_files needs file_analyzed = True.
+        ### Now pending implementation as it is unclear if this value can be set.
+        ### see https://spdx.github.io/spdx-spec/v2.3/package-information/#714-all-licenses-information-from-files-field
+        #     if 'ids' in component['licenses'] and component['licenses']['ids']:
+        #         l = []
+        #         for lid in component['licenses']['ids']:
+        #             try:
+        #                 le = Licensing().parse(lid, validate=False)
+        #                 l.append(le)
+        #             except ExpressionError as err:
+        #                 pass
+        #         pkg.license_info_from_files = l
+
+        pkg.summary = component['summary']
+        pkg.description = component['description']
 
         self._document.packages += [pkg]
         self._document.relationships += [rel]

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -254,8 +254,10 @@ class SBOM:
         #                 pass
         #         pkg.license_info_from_files = l
 
-        pkg.summary = component['summary']
-        pkg.description = component['description']
+        if 'summary' in component and component['summary']:
+            pkg.summary = component['summary']
+        if 'description' in component and component['description']:
+            pkg.description = component['description']
 
         self._document.packages += [pkg]
         self._document.relationships += [rel]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'urllib3<2.0',
         'packageurl-python==0.10.3',
         'GitPython==3.1.29',
+        'rpm',
         'immudb_wrapper @ git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.5#egg=immudb_wrapper',
     ],
     python_requires=">=3.9",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,25 @@ from setuptools import setup
 
 from version import __version__
 
+def get_requires():
+    requires=[
+        'requests>=2.20.0',
+        'cyclonedx-python-lib==2.7.1',
+        'spdx-tools==0.8',
+        'urllib3<2.0',
+        'packageurl-python==0.10.3',
+        'GitPython==3.1.29',
+        'immudb_wrapper @ git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.5#egg=immudb_wrapper',
+    ]
+
+    is_venv = sys.prefix != sys.base_prefix
+    if is_venv:
+        requires.append('rpm==0.3.1')
+    else: # not is_venv
+        requires.append('rpm>=4.14')
+
+    return requires
+
 setup(
     name="alma_sbom",
     version=__version__,
@@ -20,15 +39,6 @@ setup(
     ],
     py_modules=['alma_sbom'],
     scripts=['alma_sbom.py'],
-    install_requires=[
-        'requests>=2.20.0',
-        'cyclonedx-python-lib==2.7.1',
-        'spdx-tools==0.8',
-        'urllib3<2.0',
-        'packageurl-python==0.10.3',
-        'GitPython==3.1.29',
-        'rpm',
-        'immudb_wrapper @ git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.5#egg=immudb_wrapper',
-    ],
+    install_requires=get_requires(),
     python_requires=">=3.9",
 )


### PR DESCRIPTION
This patch allows us to add licenses and description information when using the --rpm-package option. For SPDX, a summary is also added. Note that the licenses information includes a provisional implementation, so it may be modified in the future.

However, applying this patch may cause it to stop working on distributions other than AlmaLinux and other EL-based distributions. The rpm module (rpm-shim) used to analyze information from RPM packages is a module that uses the RPM Python bindings provided by the installed python3-rpm package. python3-rpm package is installed on almost all AlmaLinux systems except for some like containers because it is a transitive dependency of the dnf package, which is installed by default in a minimal installation. However, for example on Ubuntu, there is a package with the same name python3-rpm, but alma-sbom did not work properly if I installed it.

This patch needs to merge #39