### PR TITLE
[DRAFT] PoC implementation of ISO-SBOM

### DIFF
--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -239,6 +239,121 @@ def add_package_source_info(immudb_metadata: Dict, component: Dict):
         )
 
 
+def add_package_build_info(
+    immudb_metadata: Dict, 
+    component: Dict,
+    albs_url: str,
+):
+    component['properties'].extend(
+        [
+            {
+                'name': 'almalinux:package:buildhost',
+                'value': immudb_metadata['build_host']
+                if 'build_host' in immudb_metadata
+                else None,
+            },
+            {
+                'name': 'almalinux:albs:build:targetArch',
+                'value': immudb_metadata['build_arch']
+                if 'build_arch' in immudb_metadata
+                else None,
+            },
+            {
+                'name': 'almalinux:albs:build:ID',
+                'value': immudb_metadata['build_id']
+                if 'build_id' in immudb_metadata
+                else None,
+            },
+            {
+                'name': 'almalinux:albs:build:URL',
+                'value': f'{albs_url}/build/{immudb_metadata["build_id"]}'
+                if 'build_id' in immudb_metadata
+                else None,
+            },
+            {
+                'name': 'almalinux:albs:build:author',
+                'value': immudb_metadata['built_by']
+                if 'built_by' in immudb_metadata
+                else None,
+            },
+        ]
+    )
+
+
+def add_package_info(
+    immudb_hash: str,
+    immudb_info_about_package: Dict, 
+    component: Dict,
+    albs_url: str,
+):
+    source_rpm, package_nevra = _get_specific_info_about_package(
+        immudb_info_about_package=immudb_info_about_package,
+    )
+    immudb_metadata = immudb_info_about_package['Metadata']
+
+    component['name'] = package_nevra.name
+    component['version'] = (
+        f'{package_nevra.epoch if package_nevra.epoch else ""}'
+        f'{":" if package_nevra.epoch else ""}'
+        f'{package_nevra.version}-{package_nevra.release}'
+    )
+    component['hashes'] = [
+        {
+            'alg': 'SHA-256',
+            'content': immudb_hash,
+        }
+    ]
+    component['cpe'] = _generate_cpe(package_nevra=package_nevra)
+    component['purl'] =  _generate_purl(
+        package_nevra=package_nevra,
+        source_rpm=source_rpm,
+    )
+    component['properties'] = [
+        {
+            'name': 'almalinux:package:epoch',
+            'value': package_nevra.epoch,
+        },
+        {
+            'name': 'almalinux:package:version',
+            'value': package_nevra.version,
+        },
+        {
+            'name': 'almalinux:package:release',
+            'value': package_nevra.release,
+        },
+        {
+            'name': 'almalinux:package:arch',
+            'value': package_nevra.arch,
+        },
+        {
+            'name': 'almalinux:package:sourcerpm',
+            'value': source_rpm,
+        },
+        {
+            'name': 'almalinux:package:timestamp',
+            'value': immudb_info_about_package['timestamp'],
+        },
+        {
+            'name': 'almalinux:albs:build:packageType',
+            'value': 'rpm',
+        },
+        {
+            'name': 'almalinux:sbom:immudbHash',
+            'value': immudb_hash,
+        },
+    ]
+
+    add_package_build_info(
+        immudb_metadata=immudb_metadata,
+        component=component,
+        albs_url=albs_url,
+    )
+    add_package_source_info(
+        immudb_metadata=immudb_metadata,
+        component=component,
+    )
+
+
 def get_info_about_package(
     immudb_hash: str,
     albs_url: str,
@@ -249,91 +364,17 @@ def get_info_about_package(
         immudb_hash=immudb_hash,
         immudb_wrapper=immudb_wrapper,
     )
-    source_rpm, package_nevra = _get_specific_info_about_package(
-        immudb_info_about_package=immudb_info_about_package,
-    )
     immudb_metadata = immudb_info_about_package['Metadata']
     result['version'] = 1
     if 'unsigned_hash' in immudb_metadata:
         result['version'] += 1
     result['metadata'] = {}
-    result['metadata']['component'] = {
-        'name': package_nevra.name,
-        'version': (
-            f'{package_nevra.epoch if package_nevra.epoch else ""}'
-            f'{":" if package_nevra.epoch else ""}'
-            f'{package_nevra.version}-{package_nevra.release}'
-        ),
-        'hashes': [
-            {
-                'alg': 'SHA-256',
-                'content': immudb_hash,
-            }
-        ],
-        'cpe': _generate_cpe(package_nevra=package_nevra),
-        'purl': _generate_purl(
-            package_nevra=package_nevra,
-            source_rpm=source_rpm,
-        ),
-        'properties': [
-            {
-                'name': 'almalinux:package:epoch',
-                'value': package_nevra.epoch,
-            },
-            {
-                'name': 'almalinux:package:version',
-                'value': package_nevra.version,
-            },
-            {
-                'name': 'almalinux:package:release',
-                'value': package_nevra.release,
-            },
-            {
-                'name': 'almalinux:package:arch',
-                'value': package_nevra.arch,
-            },
-            {
-                'name': 'almalinux:package:sourcerpm',
-                'value': source_rpm,
-            },
-            {
-                'name': 'almalinux:package:buildhost',
-                'value': immudb_metadata['build_host'],
-            },
-            {
-                'name': 'almalinux:package:timestamp',
-                'value': immudb_info_about_package['timestamp'],
-            },
-            {
-                'name': 'almalinux:albs:build:targetArch',
-                'value': immudb_metadata['build_arch'],
-            },
-            {
-                'name': 'almalinux:albs:build:packageType',
-                'value': 'rpm',
-            },
-            {
-                'name': 'almalinux:sbom:immudbHash',
-                'value': immudb_hash,
-            },
-            {
-                'name': 'almalinux:albs:build:ID',
-                'value': immudb_metadata['build_id'],
-            },
-            {
-                'name': 'almalinux:albs:build:URL',
-                'value': f'{albs_url}/build/{immudb_metadata["build_id"]}',
-            },
-            {
-                'name': 'almalinux:albs:build:author',
-                'value': immudb_metadata['built_by'],
-            },
-        ],
-    }
-
-    add_package_source_info(
-        immudb_metadata=immudb_metadata,
+    result['metadata']['component'] = {}
+    add_package_info(
+        immudb_hash=immudb_hash,
+        immudb_info_about_package=immudb_info_about_package,
         component=result['metadata']['component'],
+        albs_url=albs_url,
     )
     return result
 
@@ -384,77 +425,12 @@ def get_info_about_build(
                 immudb_wrapper=immudb_wrapper,
             )
             immudb_metadata = result_of_execution['Metadata']
-            source_rpm, package_nevra = _get_specific_info_about_package(
+            component = {}
+            add_package_info(
+                immudb_hash=immudb_hash,
                 immudb_info_about_package=result_of_execution,
-            )
-            component = {
-                'name': package_nevra.name,
-                'version': package_nevra.version,
-                'cpe': _generate_cpe(package_nevra=package_nevra),
-                'purl': _generate_purl(
-                    package_nevra=package_nevra,
-                    source_rpm=source_rpm,
-                ),
-                'hashes': [
-                    {
-                        'alg': 'SHA-256',
-                        'content': immudb_hash,
-                    }
-                ],
-                'properties': [
-                    {
-                        'name': 'almalinux:package:epoch',
-                        'value': package_nevra.epoch,
-                    },
-                    {
-                        'name': 'almalinux:package:version',
-                        'value': package_nevra.version,
-                    },
-                    {
-                        'name': 'almalinux:package:release',
-                        'value': package_nevra.release,
-                    },
-                    {
-                        'name': 'almalinux:package:arch',
-                        'value': package_nevra.arch,
-                    },
-                    {
-                        'name': 'almalinux:package:sourcerpm',
-                        'value': source_rpm,
-                    },
-                    {
-                        'name': 'almalinux:package:buildhost',
-                        'value': immudb_metadata['build_host'],
-                    },
-                    {
-                        'name': 'almalinux:albs:build:targetArch',
-                        'value': immudb_metadata['build_arch'],
-                    },
-                    {
-                        'name': 'almalinux:albs:build:packageType',
-                        'value': 'rpm',
-                    },
-                    {
-                        'name': 'almalinux:sbom:immudbHash',
-                        'value': result_of_execution['Hash'],
-                    },
-                    {
-                        'name': 'almalinux:albs:build:ID',
-                        'value': build_id,
-                    },
-                    {
-                        'name': 'almalinux:albs:build:URL',
-                        'value': build_url,
-                    },
-                    {
-                        'name': 'almalinux:albs:build:author',
-                        'value': immudb_metadata['built_by'],
-                    },
-                ],
-            }
-            add_package_source_info(
-                immudb_metadata=immudb_metadata,
                 component=component,
+                albs_url=albs_url,
             )
             components.append(component)
     result['components'] = components

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -5,9 +5,11 @@ import argparse
 import dataclasses
 import os
 import sys
+import rpm
 from logging import basicConfig, getLogger, DEBUG, INFO, WARNING
 from collections import defaultdict
 from typing import Dict, List, Literal, Optional, Tuple
+from license_expression import get_spdx_licensing, ExpressionError
 
 import requests
 from immudb_wrapper import ImmudbWrapper
@@ -194,6 +196,21 @@ def _generate_purl(package_nevra: PackageNevra, source_rpm: str):
     )
     return purl
 
+def _proc_licenses(licenses_str: str):
+    licensing = get_spdx_licensing()
+    l = {}
+    l['ids'] = []
+    l['expression'] = licenses_str
+    try:
+        parsed = licensing.parse(licenses_str, validate=True)
+    except ExpressionError as err:
+        pass
+    else:
+        symbols = licensing.license_symbols(parsed)
+        for sym in symbols:
+            l['ids'].append(str(sym))
+    return l
+
 
 def add_package_source_info(immudb_metadata: Dict, component: Dict):
     if immudb_metadata['source_type'] == 'git':
@@ -245,6 +262,36 @@ def add_package_source_info(immudb_metadata: Dict, component: Dict):
             ]
         )
 
+def add_rpm_package_info(
+    component: Dict,
+    rpm_package: str = None,
+):
+    if not rpm_package:
+        return
+    ts = rpm.TransactionSet()
+    try:
+        fd = os.open(rpm_package, os.O_RDONLY)
+        hdr = ts.hdrFromFdno(fd)
+    except OSError as e:
+        _logger.error(f'file open error: {e.strerror}')
+        sys.exit(1)
+    except rpm.error as e:
+        _logger.error(f'file open error: {str(e)}')
+        sys.exit(1)
+    except Exception as e:
+        _logger.error(f'unknown error: {str(e)}')
+        sys.exit(1)
+    else:
+        pass
+    finally:
+        try:
+            os.close(fd)
+        except Exception:
+            pass
+
+    component['licenses'] = _proc_licenses(hdr[rpm.RPMTAG_LICENSE])
+    component['summary'] = hdr[rpm.RPMTAG_SUMMARY]
+    component['description'] = hdr[rpm.RPMTAG_DESCRIPTION]
 
 def add_package_build_info(
     immudb_metadata: Dict, 
@@ -385,6 +432,10 @@ def get_info_about_package(
         immudb_info_about_package=immudb_info_about_package,
         component=result['metadata']['component'],
         albs_url=albs_url,
+    )
+    add_rpm_package_info(
+        component=result['metadata']['component'],
+        rpm_package=rpm_package,
     )
     return result
 

--- a/libsbom/cyclonedx.py
+++ b/libsbom/cyclonedx.py
@@ -2,7 +2,7 @@ import json
 import xml.dom.minidom
 from logging import getLogger
 
-from cyclonedx.model import HashAlgorithm, HashType, Property, OrganizationalContact
+from cyclonedx.model import HashAlgorithm, HashType, Property, OrganizationalContact, LicenseChoice
 from cyclonedx.model.bom import Bom, Tool
 from cyclonedx.model.component import Component, ComponentType
 from cyclonedx.output import OutputFormat, get_instance
@@ -86,6 +86,17 @@ class SBOM:
             hash_value=hash_['content'],
         )
 
+    @staticmethod
+    def __generate_licenses(_license):
+        l = []
+        if 'ids' in _license and _license['ids']:
+            for lid in _license['ids']:
+                l.append( LicenseChoice(license_=lid) )
+
+        elif 'expression' in _license and _license['expression']:
+            l.append( LicenseChoice(license_expression=_license['expression']) )
+        return l
+
     def __add_authors(self, authors):
         if authors != None:
             d = len(authors['name']) - len(authors['email'])
@@ -121,6 +132,9 @@ class SBOM:
             properties=[
                 self.__generate_prop(prop) for prop in comp['properties']
             ],
+            licenses=self.__generate_licenses(comp['licenses'])
+                if 'licenses' in comp and comp['licenses'] else [] ,
+            description=comp['description']
         )
 
     def generate_build_sbom(self):

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -2,6 +2,7 @@ import datetime
 import uuid
 from typing import Optional, Union
 from logging import getLogger
+from license_expression import Licensing, ExpressionError
 
 from spdx_tools.spdx.model import (
     Actor,
@@ -233,6 +234,28 @@ class SBOM:
             raise ValueError(f"Cannot determine build time of {pkg.name}")
 
         pkg.files_analyzed = False
+
+        if 'licenses' in component and component['licenses']:
+            pkg.license_concluded = SpdxNoAssertion()
+            if 'expression' in component['licenses'] and component['licenses']['expression']:
+                pkg.license_comment = component['licenses']['expression']
+
+        ### NOTE
+        ### license_info_frpm_files needs file_analyzed = True.
+        ### Now pending implementation as it is unclear if this value can be set.
+        ### see https://spdx.github.io/spdx-spec/v2.3/package-information/#714-all-licenses-information-from-files-field
+        #     if 'ids' in component['licenses'] and component['licenses']['ids']:
+        #         l = []
+        #         for lid in component['licenses']['ids']:
+        #             try:
+        #                 le = Licensing().parse(lid, validate=False)
+        #                 l.append(le)
+        #             except ExpressionError as err:
+        #                 pass
+        #         pkg.license_info_from_files = l
+
+        pkg.summary = component['summary']
+        pkg.description = component['description']
 
         self._document.packages += [pkg]
         self._document.relationships += [rel]

--- a/make_iso_sbom.py
+++ b/make_iso_sbom.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+# -*- mode:python; coding:utf-8; -*-
+
+import os
+import sys
+import collections
+import pycdlib
+import tempfile
+import configparser
+import argparse
+
+from logging import basicConfig, getLogger, DEBUG, INFO, WARNING
+from typing import Dict, List, Literal, Optional, Tuple
+
+from immudb_wrapper import ImmudbWrapper
+
+from libsbom import cyclonedx as alma_cyclonedx
+from libsbom import spdx as alma_spdx
+
+import alma_sbom
+
+
+path_to_treeinfo = '/.treeinfo'
+
+_logger = getLogger('alma-sbom')
+
+def create_parser():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '--output-file',
+        type=str,
+        help=(
+            'Full path to an output file with SBOM. Output will be '
+            'to stdout if the parameter is absent or emtpy'
+        ),
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        '--file-format',
+        default=alma_sbom.FileFormat(),
+        const=alma_sbom.FileFormat(),
+        nargs='?',
+        choices=alma_sbom.FileFormatType.choices(),
+        type=alma_sbom.FileFormatType(),
+        help='Generate SBOM in one of format mode (default: %(default)s)',
+    )
+    object_id_group = parser.add_mutually_exclusive_group(required=True)
+    object_id_group.add_argument(
+        '--iso-file',
+        type=str,
+        help='path to ISO image',
+    )
+    parser.add_argument(
+        '--immudb-username',
+        type=str,
+        help=(
+            'Provide your immudb username if not set as '
+            'an environmental variable'
+        ),
+        required=False,
+    )
+    parser.add_argument(
+        '--immudb-password',
+        type=str,
+        help=(
+            'Provide your immudb password if not set as '
+            'an environmental variable'
+        ),
+        required=False,
+    )
+    parser.add_argument(
+        '--immudb-database',
+        type=str,
+        help=(
+            'Provide your immudb database if not set as '
+            'an environmental variable'
+        ),
+        required=False,
+    )
+    parser.add_argument(
+        '--immudb-address',
+        type=str,
+        help=(
+            'Provide your immudb address if not set as '
+            'an environmental variable'
+        ),
+        required=False,
+    )
+    parser.add_argument(
+        '--immudb-public-key-file',
+        type=str,
+        help=(
+            'Provide your immudb public key file if not set as '
+            'an environmental variable'
+        ),
+        required=False,
+    )
+    parser.add_argument(
+        '--verbose',
+        help=(
+            'Print verbose output'
+        ),
+        required=False,
+        default=WARNING,
+        action='store_const', dest='loglevel', const=INFO,
+    )
+    parser.add_argument(
+        '--debug',
+        help=(
+            'Print debug log'
+        ),
+        required=False,
+        action='store_const', dest='loglevel', const=DEBUG,
+    )
+    parser.add_argument(
+        '--creator-name-person',
+        type=str,
+        action='append',
+        help=(
+            'The person(s) who create SBOM'
+        ),
+        required=False,
+        default=[],
+    )
+    parser.add_argument(
+        '--creator-email-person',
+        type=str,
+        action='append',
+        help=(
+            'The email address of SBOM creator. '
+            'This option is only required if --creator-name-personal is provided. '
+            'The combination of name and email address depends on the order specified. '
+            'If an extra email address is specified, it will be ignored'
+        ),
+        required=False,
+        default=[],
+    )
+    parser.add_argument(
+        '--creator-name-org',
+        type=str,
+        action='append',
+        help=(
+            'The organization(s) who create SBOM'
+        ),
+        required=False,
+        default=[],
+    )
+    parser.add_argument(
+        '--creator-email-org',
+        type=str,
+        action='append',
+        help=(
+            'The email address of SBOM creator. '
+            'This option is only required if --creator-name-org is provided. '
+            'The combination of name and email address depends on the order specified. '
+            'If an extra email address is specified, it will be ignored.'
+        ),
+        required=False,
+        default=[],
+    )
+
+    return parser
+
+
+def cli_main():
+    fmt = '%(asctime)s %(name)s: [%(levelname)s] %(message)s'
+    datefmt = '%b %d %H:%M:%S'
+    basicConfig(format=fmt, datefmt=datefmt)
+
+    args = create_parser().parse_args()
+
+    _logger.setLevel(args.loglevel)
+
+    immudb_wrapper = ImmudbWrapper(
+        username=(
+            args.immudb_username
+            or os.getenv('IMMUDB_USERNAME')
+            or ImmudbWrapper.read_only_username()
+        ),
+        password=(
+            args.immudb_password
+            or os.getenv('IMMUDB_PASSWORD')
+            or ImmudbWrapper.read_only_password()
+        ),
+        database=(
+            args.immudb_database
+            or os.getenv('IMMUDB_DATABASE')
+            or ImmudbWrapper.almalinux_database_name()
+        ),
+        immudb_address=(
+            args.immudb_address
+            or os.getenv('IMMUDB_ADDRESS')
+            or ImmudbWrapper.almalinux_database_address()
+        ),
+        public_key_file=(
+            args.immudb_public_key_file or os.getenv('IMMUDB_PUBLIC_KEY_FILE')
+        ),
+    )
+
+    iso = pycdlib.PyCdlib()
+    iso.open(args.iso_file)
+
+
+    index = 0
+    result = {}
+    components = []
+
+    # Read ISO directory structure from .treeinfo
+    config = configparser.ConfigParser()
+    variants = []
+    variant_packages = {}
+    with tempfile.NamedTemporaryFile(delete=True) as tmp:
+        iso.get_file_from_iso(local_path=tmp.name, rr_path=path_to_treeinfo)
+        config.read(tmp.name)
+        if 'general' in config and 'family' in config['general']:
+            if config['general']['family'] != 'AlmaLinux':
+                _logger.error('alma-sbom only can make ISO SBOM for AlmaLinux ISO Image.')
+                sys.exit(1)
+        else:
+            _logger.error('ISO file may be corrupted.')
+            sys.exit(1)
+
+        if 'general' in config and 'variants' in config['general']:
+            variants = config['general']['variants'].split(',')
+        elif 'tree' in config and 'variants' in config['tree']:
+            variants = config['tree']['variants'].split(',')
+        else:
+            _logger.error('ISO file may be corrupted.')
+            sys.exit(1)
+
+        for variant in variants:
+            section_name = f'variant-{variant}'
+            if section_name in config and 'packages' in config[section_name]:
+                variant_packages[variant] = config[section_name]['packages']
+
+    if 'general' in config and 'version' in config['general']:
+        iso_releasever = config['general']['version']
+    else:
+        _logger.error('ISO file may be corrupted.')
+        sys.exit(1)
+
+    variants_list = list(variant_packages.keys())
+    if variants_list == ['AppStream', 'BaseOS']:
+        iso_type = 'DVD'
+    elif variants_list == ['Minimal']:
+        iso_type = 'Minimal'
+    else:
+        _logger.error('ISO file may be corrupted.')
+        sys.exit(1)
+
+
+    for variant_packages_repo in variant_packages.values():
+        index = 0
+        variant_path = os.path.join('/', variant_packages_repo)
+        variant_entry = iso.get_record(iso_path=variant_path)
+        for child in variant_entry.children:
+            pkg_name = child.rock_ridge.name().decode('utf8')
+            print(pkg_name)
+            if pkg_name.endswith('.rpm'):
+                full_rr_path = os.path.join(variant_path, pkg_name)
+                full_iso_path = os.path.join(
+                                    variant_path,
+                                    child.file_identifier().decode('utf8')
+                                )
+                with tempfile.NamedTemporaryFile(delete=True) as tmp:
+                    iso.get_file_from_iso(local_path=tmp.name, rr_path=full_rr_path)
+                    response = immudb_wrapper.authenticate_file(tmp)
+                    immudb_info_about_package = response.get('value', {})
+                    immudb_info_about_package['timestamp'] = response.get('timestamp')
+                    immudb_hash = immudb_info_about_package['Hash']
+                    component = {}
+                    alma_sbom.add_package_info(
+                        immudb_hash=immudb_hash,
+                        immudb_info_about_package=immudb_info_about_package,
+                        component=component,
+                        albs_url=alma_sbom.ALBS_URL,
+                    )
+                    components.append(component)
+
+    result['components'] = components
+
+    opt_creators = alma_sbom._proc_opt_creators(
+        args.creator_name_person,
+        args.creator_email_person,
+        args.creator_name_org,
+        args.creator_email_org
+    )
+    sbom_formatter = alma_cyclonedx.SBOM(
+        data=result,
+        sbom_object_type='iso',
+        output_format=args.file_format.file_format,
+        output_file=args.output_file,
+        opt_creators=opt_creators,
+    )
+    sbom_formatter.run(
+        iso_releasever=iso_releasever, 
+        iso_type=iso_type,
+    )
+
+    iso.close()
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'urllib3<2.0',
         'packageurl-python==0.10.3',
         'GitPython==3.1.29',
+        'rpm',
         'immudb_wrapper @ git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.5#egg=immudb_wrapper',
     ],
     python_requires=">=3.9",


### PR DESCRIPTION
**This is Draft PR. DO NOT MERGE this PR.**

This PR allow us to make ISO-SBOM.
Now we can get cyclonedx-SBOM of dvd-ISO and minimal-ISO. 
At present, however, SBOMs can be generated only when the number of packages is explicitly narrowed down, not for all packages included in the ISO.
If individual package-SBOMs cannot be generated for all the packages in the ISO, the ISO-SBOM cannot be generated either.
At this time, I've found some packages for which package-SBOMs cannot be generated, and we plan to fix this in other MR.

Moreover, the following implementations and considerations need to be addressed, and once they are resolved, the draft status is expected to be removed:
 - Implementation for spdx
 - Implementation for boot ISO (If we can, and If we need) 
 - Consideration about the contents of ISO-SBOM (now it includes only packages info)
 - Resolve individual package-SBOMs issue & Enable generation of complete ISO-SBOMs
 - other refactors