### PR TITLE
[DRAFT] Fix some incomplete metadata issue partially

### DIFF
--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -406,11 +406,13 @@ def comp_package_info(
     is_required_data, missing_fields = common.check_required_data(immudb_metadata, required_fields)
     if not is_required_data:
         _logger.warning('Required data are missing')
+        _logger.debug(f'missing_required_field: {missing_fields}')
         if ts is None:
             raise ValueError('Cannot get required package info from immudb or The data is lacking.')
         else:
             _logger.warning('Complete the data from the RPM package information.')
             for field in missing_fields:
+                _logger.debug(f'Complete {field}-field with {hdr[dict_field_rpmtag[field]]}')
                 immudb_metadata[field] = hdr[dict_field_rpmtag[field]]
     ### NOTE
     ### There are little bit difference of buildtime between immudb_metadata & rpm_package.

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -116,10 +116,17 @@ def generate_sbom_version(json_data: Dict) -> int:
 
 
 def _extract_immudb_info_about_package(
-    immudb_hash: str,
     immudb_wrapper: ImmudbWrapper,
+    immudb_hash: str = None,
+    rpm_package: str = None,
 ) -> Dict:
-    response = immudb_wrapper.authenticate(immudb_hash)
+    if immudb_hash != None :
+        response = immudb_wrapper.authenticate(immudb_hash)
+    elif rpm_package != None :
+        if not os.path.exists(rpm_package):
+            logging.error(f'File {rpm_package} Not Found')
+            sys.exit(1)
+        response = immudb_wrapper.authenticate_file(rpm_package)
     result = response.get('value', {})
     result['timestamp'] = response.get('timestamp')
     return result
@@ -240,18 +247,21 @@ def add_package_source_info(immudb_metadata: Dict, component: Dict):
 
 
 def get_info_about_package(
-    immudb_hash: str,
     albs_url: str,
     immudb_wrapper: ImmudbWrapper,
+    immudb_hash: str = None,
+    rpm_package: str = None,
 ):
     result = {}
     immudb_info_about_package = _extract_immudb_info_about_package(
-        immudb_hash=immudb_hash,
         immudb_wrapper=immudb_wrapper,
+        immudb_hash=immudb_hash,
+        rpm_package=rpm_package,
     )
     source_rpm, package_nevra = _get_specific_info_about_package(
         immudb_info_about_package=immudb_info_about_package,
     )
+    immudb_hash = immudb_hash or immudb_info_about_package['Hash']
     immudb_metadata = immudb_info_about_package['Metadata']
     result['version'] = 1
     if 'unsigned_hash' in immudb_metadata:
@@ -380,8 +390,8 @@ def get_info_about_build(
                 continue
             immudb_hash = artifact['cas_hash']
             result_of_execution = _extract_immudb_info_about_package(
-                immudb_hash=immudb_hash,
                 immudb_wrapper=immudb_wrapper,
+                immudb_hash=immudb_hash,
             )
             immudb_metadata = result_of_execution['Metadata']
             source_rpm, package_nevra = _get_specific_info_about_package(
@@ -514,6 +524,11 @@ def create_parser():
         '--rpm-package-hash',
         type=str,
         help='SHA256 hash of an RPM package',
+    )
+    object_id_group.add_argument(
+        '--rpm-package',
+        type=str,
+        help='path to an RPM package',
     )
     parser.add_argument(
         '--albs-url',
@@ -685,9 +700,10 @@ def cli_main():
         sbom_object_type = 'build'
     else:
         sbom = get_info_about_package(
-            args.rpm_package_hash,
             albs_url=albs_url,
             immudb_wrapper=immudb_wrapper,
+            immudb_hash=args.rpm_package_hash,
+            rpm_package=args.rpm_package,
         )
         sbom_object_type = 'package'
     opt_creators = _proc_opt_creators(

--- a/alma_sbom.py
+++ b/alma_sbom.py
@@ -124,7 +124,7 @@ def _extract_immudb_info_about_package(
         response = immudb_wrapper.authenticate(immudb_hash)
     elif rpm_package != None :
         if not os.path.exists(rpm_package):
-            logging.error(f'File {rpm_package} Not Found')
+            _logger.error(f'File {rpm_package} Not Found')
             sys.exit(1)
         response = immudb_wrapper.authenticate_file(rpm_package)
     result = response.get('value', {})

--- a/libsbom/common.py
+++ b/libsbom/common.py
@@ -1,5 +1,26 @@
 import typing
 
+def check_required_data(
+        data_dict: typing.Dict[str, any],
+        required_fields: typing.List[str],
+    ) -> typing.Tuple[bool, typing.List[str]]:
+    """
+    Check if all the required fields exist in the specified data dictionary
+
+    Args:
+        data_dict (Dict[str, any]): A dictionary containing the data to be checked
+        required_fields (List[str]): A list of required field names
+
+    Returns:
+        Tuple[bool, List[str]]:
+            - bool: If all required fields exist, return True; otherwise, return False
+            - List[str]: A list of missing field names
+    """
+
+    missing_fields = [field for field in required_fields if field not in data_dict]
+    return not bool(missing_fields), missing_fields
+
+
 def replace_patterns(input_str: str, patterns: typing.Dict[str, str]) -> str:
     """Convenience function to perform multiple string replacements."""
 

--- a/libsbom/spdx.py
+++ b/libsbom/spdx.py
@@ -229,8 +229,6 @@ class SBOM:
         pkg.built_date = component_get_buildtime(
             component
         ) or build_get_timestamp(build)
-        if not pkg.built_date:
-            raise ValueError(f"Cannot determine build time of {pkg.name}")
 
         pkg.files_analyzed = False
 


### PR DESCRIPTION
When data cannot be retrieved from immudb, or when data for package is
missing, if the --rpm-package option was used to specify an rpm package,
I made it so that the rpm package is used to supplement the information.

The following issues have been partially fixed.
 - https://github.com/AlmaLinux/alma-sbom/issues/42
 - https://github.com/AlmaLinux/alma-sbom/issues/44

And the following issues have been fixed.
 - https://github.com/AlmaLinux/alma-sbom/issues/26

Note1:
This MR nees to merge https://github.com/AlmaLinux/alma-sbom/pull/39 .
Please merge that MR first.

Note2:
This MR may conflict with other MRs.
(At least, it will definitely conflict with #45.)
I will resolve the conflicts after #45 is merged, so please let me know when that happens.
Also, alma_sbom.py has become bloated, and there have been many conflicts in the past. We may need to reconsider its structure.