### PR TITLE
Implementation of ISO-SBOM

### DIFF
--- a/alma_sbom/cli/commands/__init__.py
+++ b/alma_sbom/cli/commands/__init__.py
@@ -5,10 +5,12 @@ from alma_sbom.cli.config import CommonConfig
 from .commands import SubCommand
 from .package import PackageCommand
 from .build import BuildCommand
+from .iso import IsoCommand
 
 command_classes: dict[str, type[SubCommand]] = {
     'package': PackageCommand,
-    'build': BuildCommand
+    'build': BuildCommand,
+    'iso': IsoCommand,
 }
 
 def command_factory(base: CommonConfig, args: argparse.Namespace) -> SubCommand:

--- a/alma_sbom/cli/commands/iso.py
+++ b/alma_sbom/cli/commands/iso.py
@@ -5,8 +5,7 @@ from typing import ClassVar, TYPE_CHECKING
 
 from alma_sbom.cli.config import CommonConfig, IsoConfig
 
-### TODO:
-##  We should avoid importing modules from outside the CLI layer except for TYPE_CHECKING
+### TODO: https://github.com/AlmaLinux/alma-sbom/issues/59
 from alma_sbom.data import NullPackage
 
 from .commands import SubCommand

--- a/alma_sbom/cli/commands/iso.py
+++ b/alma_sbom/cli/commands/iso.py
@@ -1,0 +1,53 @@
+import argparse
+import tempfile
+from logging import getLogger
+from typing import ClassVar, TYPE_CHECKING
+
+from alma_sbom.cli.config import CommonConfig, IsoConfig
+
+### TODO:
+##  We should avoid importing modules from outside the CLI layer except for TYPE_CHECKING
+from alma_sbom.data import NullPackage
+
+from .commands import SubCommand
+
+_logger = getLogger(__name__)
+
+class IsoCommand(SubCommand):
+    CONFIG_CLASS : ClassVar[type[CommonConfig]] = IsoConfig
+    config: IsoConfig
+
+    def run(self) -> int:
+        iso = self.runner()
+        doc = self.document_factory.gen_from_iso(iso)
+        doc.write(self.config.output_file)
+        return 0
+
+    def _select_runner(self) -> None:
+        if self.config.iso_image:
+            self.runner = self._runner_with_iso_image
+        else:
+            raise RuntimeError('Unexpected situation has occurred')
+
+    def _runner_with_iso_image(self) -> 'Iso':
+        iso_collector = self.collector_factory.gen_iso_collector()
+        immudb_collector = self.collector_factory.gen_immudb_collector()
+        rpm_collector = self.collector_factory.gen_rpm_collector()
+
+        iso = iso_collector.collect_iso_by_file(self.config.iso_image)
+
+        count = 1
+        fd_path = iso_collector.get_fd_path()
+        for _ in iso_collector.iter_packages():
+            _logger.debug(f'Processing package #{count}...')
+            count = count + 1
+            try:
+                pkg_from_immudb = immudb_collector.collect_package_by_package(fd_path)
+            except KeyError as e:
+                pkg_from_immudb = NullPackage
+            pkg_from_pkg = rpm_collector.collect_package_from_file(fd_path)
+            pkg_merged = pkg_from_immudb.merge(pkg_from_pkg)
+            iso.append_package(pkg_merged)
+
+        return iso
+

--- a/alma_sbom/cli/config/__init__.py
+++ b/alma_sbom/cli/config/__init__.py
@@ -4,6 +4,7 @@ from .config import CommonConfig
 from .commands import (
     PackageConfig,
     BuildConfig,
+    IsoConfig,
     setup_subparsers,
 )
 

--- a/alma_sbom/cli/config/commands/__init__.py
+++ b/alma_sbom/cli/config/commands/__init__.py
@@ -4,10 +4,12 @@ from alma_sbom.cli.config import CommonConfig
 
 from .package import PackageConfig
 from .build import BuildConfig
+from .iso import IsoConfig
 
 subconfig_classes: dict[str, type[CommonConfig]] = {
     'package': PackageConfig,
     'build': BuildConfig,
+    'iso': IsoConfig,
 }
 
 def setup_subparsers(subparsers: argparse._SubParsersAction) -> None:

--- a/alma_sbom/cli/config/commands/iso.py
+++ b/alma_sbom/cli/config/commands/iso.py
@@ -1,0 +1,38 @@
+import argparse
+from dataclasses import dataclass
+
+from alma_sbom.cli.config import CommonConfig
+
+@dataclass
+class IsoConfig(CommonConfig):
+    iso_image: str = None
+
+    def __post_init__(self) -> None:
+        self._validate()
+        super().__post_init__()
+
+    def _validate(self) -> None:
+        if not self.iso_image:
+            raise ValueError(
+                'Unexpected situation has occurred'
+                'iso_image must not be empty'
+            )
+
+    @classmethod
+    def from_base(cls, base: CommonConfig, iso_image: str) -> 'BuildConfig':
+        base_fields = vars(base)
+        return cls(**base_fields, iso_image=iso_image)
+
+    @classmethod
+    def from_base_args(cls, base: CommonConfig, args: argparse.Namespace) -> 'BuildConfig':
+        return cls.from_base(base, iso_image=args.iso_image)
+
+    @staticmethod
+    def add_arguments(parser: argparse._SubParsersAction) -> None:
+        build_parser = parser.add_parser('iso', help='Generate ISO SBOM')
+        build_parser.add_argument(
+            '--iso-image',
+            type=str,
+            help='Path to AlmaLinux installer ISO9660 image',
+            required=True,
+        )

--- a/alma_sbom/cli/factory/collectors/factory.py
+++ b/alma_sbom/cli/factory/collectors/factory.py
@@ -3,6 +3,7 @@ from alma_sbom.data import (
     ImmudbCollector,
     AlbsCollector,
     RpmCollector,
+    IsoCollector,
 )
 
 class CollectorFactory:
@@ -27,4 +28,7 @@ class CollectorFactory:
 
     def gen_rpm_collector(self) -> RpmCollector:
         return RpmCollector()
+
+    def gen_iso_collector(self) -> IsoCollector:
+        return IsoCollector()
 

--- a/alma_sbom/cli/factory/documents/factory.py
+++ b/alma_sbom/cli/factory/documents/factory.py
@@ -20,3 +20,6 @@ class DocumentFactory:
     def gen_from_build(self, build: Any) -> Document:
         return self.document_class.from_build(build, self.config.sbom_type.file_format_type)
 
+    def gen_from_iso(self, iso: Any) -> Document:
+        return self.document_class.from_iso(iso, self.config.sbom_type.file_format_type)
+

--- a/alma_sbom/data/__init__.py
+++ b/alma_sbom/data/__init__.py
@@ -1,3 +1,3 @@
-from .models import Package, NullPackage, Build, PackageNevra
-from .collectors import ImmudbCollector, AlbsCollector, RpmCollector
+from .models import Package, NullPackage, Build, PackageNevra, Iso
+from .collectors import ImmudbCollector, AlbsCollector, RpmCollector, IsoCollector
 from .attributes import Property

--- a/alma_sbom/data/collectors/__init__.py
+++ b/alma_sbom/data/collectors/__init__.py
@@ -1,3 +1,4 @@
 from .immudb import ImmudbCollector
 from .albs import AlbsCollector
 from .rpm import RpmCollector
+from .iso import IsoCollector

--- a/alma_sbom/data/collectors/iso.py
+++ b/alma_sbom/data/collectors/iso.py
@@ -1,0 +1,104 @@
+import configparser
+import io
+import os
+import pycdlib
+import tempfile
+from typing import ClassVar, Iterator
+
+from alma_sbom.data import Iso
+
+class IsoCollector:
+    PATH_TO_TREEINFO: ClassVar[str] = '/.treeinfo'
+    DVD_REPO_LIST: ClassVar[list[str]] = ['AppStream', 'BaseOS']
+    MINIMAL_REPO_LIST: ClassVar[list[str]] = ['Minimal']
+
+    iso: pycdlib.PyCdlib
+    config: configparser.ConfigParser
+    memfd_path: int
+    repositories_info: dict
+
+    def __init__(self):
+        self.iso = pycdlib.PyCdlib()
+        self.config = configparser.ConfigParser()
+        memfd = os.memfd_create('package', flags=0)
+        self.memfd_path = f'/proc/self/fd/{memfd}'
+
+    def collect_iso_by_file(self, iso_image: str) -> Iso: ### Path にすべきかも
+        self._read_iso(iso_image)
+        self._check_almalinux_iso()
+
+        self.repositories_info = self._get_repositories_info()
+
+        releasever = self._get_releasever()
+        image_type = self._get_image_type(self.repositories_info)
+
+        return Iso(
+            releasever,
+            image_type,
+            packages=[],
+        )
+
+    def get_fd_path(self) -> int:
+        return self.memfd_path
+
+    def iter_packages(self) -> Iterator[None]:
+        for variant_packages_repo in self.repositories_info.values():
+            for _ in self._iter_packages_per_repo(variant_packages_repo):
+                yield
+
+    def _read_iso(self, iso_image: str) -> None:
+        self.iso.open(iso_image)
+        with tempfile.NamedTemporaryFile(delete=True) as tmp:
+            self.iso.get_file_from_iso(local_path=tmp.name, rr_path=self.PATH_TO_TREEINFO)
+            self.config.read(tmp.name)
+
+    def _check_almalinux_iso(self) -> None:
+        if 'general' in self.config and 'family' in self.config['general']:
+            if self.config['general']['family'] != 'AlmaLinux':
+                raise ValueError(f"alma-sbom only can make ISO SBOM for AlmaLinux ISO image. This is ISO image of {self.config['general']['family']}")
+        else:
+            raise KeyError(f'Can not detect OS name.')
+
+    def _get_repositories_info(self) -> dict:
+        variants = []
+        if 'general' in self.config and 'variants' in self.config['general']:
+            variants = self.config['general']['variants'].split(',')
+        elif 'tree' in self.config and 'variants' in self.config['tree']:
+            variants = self.config['tree']['variants'].split(',')
+        else:
+            raise KeyError(f'Can not get repositories(variants) info.')
+        variant_packages = {}
+        for variant in variants:
+            section_name = f'variant-{variant}'
+            if section_name in self.config and 'packages' in self.config[section_name]:
+                variant_packages[variant] = self.config[section_name]['packages']
+            else:
+                raise RuntimeError('Unexpected situation has occurred')
+        return variant_packages
+
+    def _get_releasever(self) -> str:
+        if 'general' in self.config and 'version' in self.config['general']:
+            return self.config['general']['version']
+        raise KeyError('Cat not detect OS version.')
+
+    def _get_image_type(self, repositories_info: dict) -> str:
+        repositories_list = list(repositories_info.keys())
+        if repositories_list == self.DVD_REPO_LIST:
+            return 'DVD'
+        elif repositories_list == self.MINIMAL_REPO_LIST:
+            return 'Minimal'
+        raise KeyError('Cat not detect image type.')
+
+    def _iter_packages_per_repo(self, variant_packages_repo: str) -> Iterator[None]:
+        variant_path = os.path.join('/', variant_packages_repo)
+        variant_entry = self.iso.get_record(iso_path=variant_path)
+        for child in variant_entry.children:
+            pkg_name = child.rock_ridge.name().decode('utf8')
+            if pkg_name.endswith('.rpm'):
+                full_rr_path = os.path.join(variant_path, pkg_name)
+                self.iso.get_file_from_iso(
+                    local_path=self.memfd_path,
+                    rr_path=full_rr_path,
+                )
+                yield
+

--- a/alma_sbom/data/collectors/iso.py
+++ b/alma_sbom/data/collectors/iso.py
@@ -23,7 +23,7 @@ class IsoCollector:
         memfd = os.memfd_create('package', flags=0)
         self.memfd_path = f'/proc/self/fd/{memfd}'
 
-    def collect_iso_by_file(self, iso_image: str) -> Iso: ### Path にすべきかも
+    def collect_iso_by_file(self, iso_image: str) -> Iso:
         self._read_iso(iso_image)
         self._check_almalinux_iso()
 

--- a/alma_sbom/data/models/__init__.py
+++ b/alma_sbom/data/models/__init__.py
@@ -1,2 +1,3 @@
 from .package import Package, NullPackage, PackageNevra
 from .build import Build
+from .iso import Iso

--- a/alma_sbom/data/models/iso.py
+++ b/alma_sbom/data/models/iso.py
@@ -1,0 +1,17 @@
+
+from dataclasses import dataclass, field
+
+from .package import Package
+
+@dataclass
+class Iso:
+    releasever: int
+    image_type: str
+
+    packages: list[Package] = field(default_factory=list)
+
+    def append_package(self, package: Package) -> None:
+        self.packages.append(package)
+
+    def get_doc_name(self) -> str:
+        return f'AlmaLinux {self.releasever} {self.image_type} ISO'

--- a/alma_sbom/formats/cyclonedx/component.py
+++ b/alma_sbom/formats/cyclonedx/component.py
@@ -7,7 +7,7 @@ from packageurl import PackageURL
 
 from alma_sbom import constants
 from alma_sbom.type import Hash, Algorithms, Licenses
-from alma_sbom.data import Package, Build, Property
+from alma_sbom.data import Package, Build, Iso, Property
 
 _logger = getLogger(__name__)
 lc_factory = LicenseFactory()
@@ -38,6 +38,12 @@ def component_from_build(build: Build) -> Component:
         properties=[
             _make_property(prop) for prop in build.get_properties()
         ],
+    )
+
+def component_from_iso(iso: Iso) -> Component:
+    return Component(
+        component_type=ComponentType('operating-system'),
+        name=iso.get_doc_name(),
     )
 
 def _make_hash(hash: Hash) -> HashType:

--- a/alma_sbom/formats/cyclonedx/document.py
+++ b/alma_sbom/formats/cyclonedx/document.py
@@ -12,11 +12,11 @@ if TYPE_CHECKING:
     from cyclonedx.output import BaseOutput
 
 from alma_sbom import constants
-from alma_sbom.data.models import Package, Build
+from alma_sbom.data.models import Package, Build, Iso
 from alma_sbom.type import SbomFileFormatType
 from alma_sbom.formats.document import Document as AlmasbomDocument
 
-from .component import component_from_package, component_from_build
+from .component import component_from_package, component_from_build, component_from_iso
 
 _logger = getLogger(__name__)
 
@@ -74,6 +74,16 @@ class CDXDocument(AlmasbomDocument):
 
         doc.bom.metadata.component = component_from_build(build)
         for pkg in build.packages:
+            doc.bom.components.add(component_from_package(pkg))
+
+        return doc
+
+    @classmethod
+    def from_iso(cls, iso: Iso, file_format_type: SbomFileFormatType) -> "CDXDocument":
+        doc = cls(file_format_type)
+
+        doc.bom.metadata.component = component_from_iso(iso)
+        for pkg in iso.packages:
             doc.bom.components.add(component_from_package(pkg))
 
         return doc

--- a/alma_sbom/formats/document.py
+++ b/alma_sbom/formats/document.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 
-from alma_sbom.data.models import Package, Build
+from alma_sbom.data.models import Package, Build, Iso
 from alma_sbom.type import SbomFileFormatType
 
 class Document(ABC):
@@ -12,6 +12,11 @@ class Document(ABC):
     @classmethod
     @abstractmethod
     def from_build(cls, build: Build, file_format_type: SbomFileFormatType) -> 'Document':
+        pass
+
+    @classmethod
+    @abstractmethod
+    def from_iso(cls, iso: Iso, file_format_type: SbomFileFormatType) -> 'Document':
         pass
 
     @abstractmethod

--- a/alma_sbom/formats/spdx/component.py
+++ b/alma_sbom/formats/spdx/component.py
@@ -17,7 +17,7 @@ from spdx_tools.spdx.model.spdx_no_assertion import SpdxNoAssertion
 from alma_sbom import constants
 from alma_sbom._version import __version__
 from alma_sbom.type import Hash, Algorithms
-from alma_sbom.data import Package, Build, Property
+from alma_sbom.data import Package, Build, Iso, Property
 
 from . import constants as spdx_consts
 
@@ -49,6 +49,9 @@ def set_build_component(document: Document, build: Build, pkgid: int) -> None:
         if prop is not None and prop.value is not None:
             note = _make_annotation(prop, pkgid)
             document.annotations += [note]
+
+def set_iso_component(document: Document, iso: Iso, pkgid: int) -> None:
+    pass
 
 def component_from_package(package: Package, pkgid: int) -> tuple[PackageComponent, Relationship]:
     pkg = PackageComponent(

--- a/alma_sbom/formats/spdx/document.py
+++ b/alma_sbom/formats/spdx/document.py
@@ -13,11 +13,11 @@ from spdx_tools.spdx.writer.xml import xml_writer
 from spdx_tools.spdx.writer.yaml import yaml_writer
 
 from alma_sbom.type import SbomFileFormatType
-from alma_sbom.data.models import Package, Build
+from alma_sbom.data.models import Package, Build, Iso
 from alma_sbom.formats.document import Document as AlmasbomDocument
 
 from . import constants as spdx_consts
-from .component import set_package_component, set_build_component
+from .component import set_package_component, set_build_component, set_iso_component
 
 _logger = getLogger(__name__)
 
@@ -75,6 +75,18 @@ class SPDXDocument(AlmasbomDocument):
         set_build_component(doc.document, build, doc.document.creation_info.spdx_id)
 
         for pkg in build.packages:
+            doc._add_each_package_component(pkg)
+
+        return doc
+
+    @classmethod
+    def from_iso(cls, iso: Iso, file_format_type: SbomFileFormatType) -> "SPDXDocument":
+        doc_name = iso.get_doc_name()
+        doc = cls(file_format_type, doc_name)
+
+        set_iso_component(doc.document, iso, doc.document.creation_info.spdx_id)
+
+        for pkg in iso.packages:
             doc._add_each_package_component(pkg)
 
         return doc

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ def get_install_requires():
         'packageurl-python==0.16.0',
         'GitPython==3.1.29',
         'immudb_wrapper @ git+https://github.com/AlmaLinux/immudb-wrapper.git@0.1.5#egg=immudb_wrapper',
+        'pycdlib==1.14.0',
     ]
 
     is_venv = sys.prefix != sys.base_prefix


### PR DESCRIPTION
This PR allow us to make ISO-SBOM.

Implement iso subcommand and we can run it like below:
```
$ alma-sbom [--debug] iso --iso-image [/path/to/isoimage]
```

It supports only AlmaLinux dvd-ISO & minilam-ISO.
It supports all formats which alma-sbom already support.