### PR TITLE
Update purl to add distro qualifier

### DIFF
--- a/alma_sbom/type.py
+++ b/alma_sbom/type.py
@@ -168,9 +168,16 @@ class PackageNevra:
             purl_epoch_part = f'&epoch={self.epoch}'
         else:
             purl_epoch_part = ''
+
+        major_ver = self.get_major_version()
+        if major_ver:
+            purl_distro_part = f'&distro=almalinux-{major_ver}'
+        else:
+            purl_distro_part = ''
+
         purl = (
             f'pkg:rpm/almalinux/{self.name}@{self.version}-'
-            f'{self.release}?arch={self.arch}{purl_epoch_part}'
+            f'{self.release}?arch={self.arch}{purl_epoch_part}{purl_distro_part}'
         )
         return purl
 
@@ -207,6 +214,13 @@ class PackageNevra:
                 return '\\' + char
 
         return re.sub(f'[^{allowed_chars}]', encode_char, cpe)
+
+    def get_major_version(self) -> Optional[int]:
+        if self.release:
+            match = re.search(r'el(\d+)', self.release.lower())
+            if match:
+                return int(match.group(1))
+        return None
 
 @dataclass
 class Licenses:


### PR DESCRIPTION
In the purl specification, the 'distro' qualifier is used to indicate which distribution the SBOM is for.
https://github.com/package-url/purl-spec?tab=readme-ov-file#purl

Some SBOM tools use the 'distro' value for detecting distributions, and our (Cybertrust's) SBOM tool also uses this 'distro' qualifier.
I modified alma-sbom to add the distro value in the purl