### PR TITLE
feat: add logger with Alma SBOM format (#6)

### DIFF
--- a/alma_sbom/__init__.py
+++ b/alma_sbom/__init__.py
@@ -1,0 +1,14 @@
+# alma_sbom/__init__.py
+
+import logging
+
+logger = logging.getLogger("alma-sbom")
+logger.setLevel(logging.INFO)
+
+handler = logging.StreamHandler()
+formatter = logging.Formatter("%(asctime)s - Alma SBOM - %(levelname)s - %(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+logger.info("Logger initialized")
+

--- a/alma_sbom/type.py
+++ b/alma_sbom/type.py
@@ -3,6 +3,10 @@ import re
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
+from alma_sbom import logger
+
+logger.info("type.py module loaded")
+
 
 class SbomRecordType(Enum):
     SPDX = 'spdx'
@@ -226,4 +230,5 @@ class PackageNevra:
 class Licenses:
     ids: list[str]
     expression: str
+
 


### PR DESCRIPTION
This PR implements a structured logger for the alma-sbom project as requested in issue #6.

- Logger initialized in `alma_sbom/__init__.py`
- Log format includes "Alma SBOM"
- Example usage added to `type.py`