### PR TITLE
Update to use pathlib.Path (#58)

### DIFF
--- a/alma_sbom/cli/config/commands/iso.py
+++ b/alma_sbom/cli/config/commands/iso.py
@@ -1,11 +1,12 @@
 import argparse
 from dataclasses import dataclass
+from pathlib import Path
 
 from alma_sbom.cli.config import CommonConfig
 
 @dataclass
 class IsoConfig(CommonConfig):
-    iso_image: str = None
+    iso_image: Path = None
 
     def __post_init__(self) -> None:
         self._validate()
@@ -19,13 +20,13 @@ class IsoConfig(CommonConfig):
             )
 
     @classmethod
-    def from_base(cls, base: CommonConfig, iso_image: str) -> 'BuildConfig':
+    def from_base(cls, base: CommonConfig, iso_image: Path) -> 'BuildConfig':
         base_fields = vars(base)
         return cls(**base_fields, iso_image=iso_image)
 
     @classmethod
     def from_base_args(cls, base: CommonConfig, args: argparse.Namespace) -> 'BuildConfig':
-        return cls.from_base(base, iso_image=args.iso_image)
+        return cls.from_base(base, iso_image=Path(args.iso_image))
 
     @staticmethod
     def add_arguments(parser: argparse._SubParsersAction) -> None:

--- a/alma_sbom/cli/config/commands/package.py
+++ b/alma_sbom/cli/config/commands/package.py
@@ -1,13 +1,14 @@
 import argparse
 import os
 from dataclasses import dataclass, asdict
+from pathlib import Path
 
 from alma_sbom.cli.config import CommonConfig
 
 @dataclass
 class PackageConfig(CommonConfig):
     rpm_package_hash: str = None
-    rpm_package: str = None
+    rpm_package: Path = None
 
     def __post_init__(self) -> None:
         self._validate()
@@ -20,17 +21,17 @@ class PackageConfig(CommonConfig):
                 'Unexpected situation has occurred. '
                 'Either rpm_package_hash or rpm_package must be specified.'
             )
-        if self.rpm_package and not os.path.exists(self.rpm_package):
+        if self.rpm_package and not self.rpm_package.exists():
             raise FileNotFoundError(f"File '{self.rpm_package}' not found")
 
     @classmethod
-    def from_base(cls, base: CommonConfig, rpm_package_hash: str, rpm_package: str) -> 'PackageConfig':
+    def from_base(cls, base: CommonConfig, rpm_package_hash: str, rpm_package: Path) -> 'PackageConfig':
         base_fields = vars(base)
         return cls(**base_fields, rpm_package_hash=rpm_package_hash, rpm_package=rpm_package)
 
     @classmethod
     def from_base_args(cls, base: CommonConfig, args: argparse.Namespace) -> 'PackageConfig':
-        return cls.from_base(base, rpm_package_hash=args.rpm_package_hash, rpm_package=args.rpm_package)
+        return cls.from_base(base, rpm_package_hash=args.rpm_package_hash, rpm_package=Path(args.rpm_package))
 
     @staticmethod
     def add_arguments(parser: argparse._SubParsersAction) -> None:

--- a/alma_sbom/cli/config/config.py
+++ b/alma_sbom/cli/config/config.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 from typing import Union, ClassVar
 from logging import getLogger
+from pathlib import Path
 from immudb_wrapper import ImmudbWrapper
 
 from alma_sbom.type import SbomType
@@ -27,7 +28,7 @@ class CommonConfig:
     DEF_IMMUDB_PUBLIC_KEY_FILE: ClassVar[str] = os.getenv('IMMUDB_PUBLIC_KEY_FILE')
 
     ### output related settings ###
-    output_file: str
+    output_file: Path
     sbom_type: SbomType
 
     ### ALBS settings ###
@@ -64,7 +65,7 @@ class CommonConfig:
                 'sbom_type info is not provided correctly.'
             )
         return cls(
-            output_file,
+            Path(output_file),
             sbom_type,
             albs_url,
             immudb_username,

--- a/alma_sbom/data/collectors/immudb/collector.py
+++ b/alma_sbom/data/collectors/immudb/collector.py
@@ -1,6 +1,7 @@
 import os
 from immudb_wrapper import ImmudbWrapper
 from logging import getLogger
+from pathlib import Path
 
 from alma_sbom.data import Package, PackageNevra
 
@@ -34,8 +35,8 @@ class ImmudbCollector:
         self.processor = processor_factory(immudb_info, hash)
         return self.processor.get_package()
 
-    def collect_package_by_package(self, rpm_package: str) -> Package:
-        immudb_info = self._extract_immudb_info_about_package(rpm_package=rpm_package)
+    def collect_package_by_package(self, rpm_package: Path) -> Package:
+        immudb_info = self._extract_immudb_info_about_package(rpm_package=str(rpm_package))
         self.processor = processor_factory(immudb_info, hash=None)
         return self.processor.get_package()
 

--- a/alma_sbom/data/collectors/iso.py
+++ b/alma_sbom/data/collectors/iso.py
@@ -24,7 +24,7 @@ class IsoCollector:
         memfd = os.memfd_create('package', flags=0)
         self.memfd_path = Path(f'/proc/self/fd/{memfd}')
 
-    def collect_iso_by_file(self, iso_image: str) -> Iso:
+    def collect_iso_by_file(self, iso_image: Path) -> Iso:
         self._read_iso(iso_image)
         self._check_almalinux_iso()
 
@@ -39,15 +39,15 @@ class IsoCollector:
             packages=[],
         )
 
-    def get_fd_path(self) -> str:
-        return str(self.memfd_path)
+    def get_fd_path(self) -> Path:
+        return self.memfd_path
 
     def iter_packages(self) -> Iterator[None]:
         for variant_packages_repo in self.repositories_info.values():
             for _ in self._iter_packages_per_repo(variant_packages_repo):
                 yield
 
-    def _read_iso(self, iso_image: str) -> None:
+    def _read_iso(self, iso_image: Path) -> None:
         self.iso.open(iso_image)
         with tempfile.NamedTemporaryFile(delete=True) as tmp:
             self.iso.get_file_from_iso(local_path=tmp.name, rr_path=str(self.PATH_TO_TREEINFO))

--- a/alma_sbom/data/collectors/rpm.py
+++ b/alma_sbom/data/collectors/rpm.py
@@ -1,6 +1,8 @@
 import hashlib
 import rpm
 from license_expression import get_spdx_licensing, ExpressionError
+from pathlib import Path
+from typing import Union
 
 from alma_sbom.type import Hash, Licenses
 from alma_sbom.data.models import Package, PackageNevra
@@ -11,7 +13,7 @@ class RpmCollector:
     def __init__(self):
         self.ts = rpm.TransactionSet()
 
-    def collect_package_from_file(self, rpm_package: str) -> Package:
+    def collect_package_from_file(self, rpm_package: Path) -> Package:
         try:
             with open(rpm_package) as fd:
                 hdr = self.ts.hdrFromFdno(fd)
@@ -70,7 +72,7 @@ def _proc_licenses(licenses_str: str) -> Licenses:
             licenses.ids.append(str(sym))
     return licenses
 
-def hash_file(file_path: str, buff_size: int = 1048576) -> str:
+def hash_file(file_path: Union[str, Path], buff_size: int = 1048576) -> str:
     """
     Returns SHA256 checksum (hexadecimal digest) of the file.
 

--- a/alma_sbom/formats/cyclonedx/document.py
+++ b/alma_sbom/formats/cyclonedx/document.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import TYPE_CHECKING
 from logging import getLogger
+from pathlib import Path
 
 from cyclonedx.builder.this import this_component as cdx_lib_component
 from cyclonedx.model.bom import Bom
@@ -88,7 +89,7 @@ class CDXDocument(AlmasbomDocument):
 
         return doc
 
-    def write(self, output_file: str) -> None:
+    def write(self, output_file: Path) -> None:
         pretty_output = self.formatter.write(self.bom)
         with open(output_file, 'w') as fd:
             fd.write(pretty_output)

--- a/alma_sbom/formats/document.py
+++ b/alma_sbom/formats/document.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 
 from alma_sbom.data.models import Package, Build, Iso
 from alma_sbom.type import SbomFileFormatType
@@ -20,6 +21,6 @@ class Document(ABC):
         pass
 
     @abstractmethod
-    def write(self, output_file: str) -> None:
+    def write(self, output_file: Path) -> None:
         pass
 

--- a/alma_sbom/formats/spdx/document.py
+++ b/alma_sbom/formats/spdx/document.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Callable
 from logging import getLogger
+from pathlib import Path
 from spdx_tools.spdx.model import (
     CreationInfo,
     Document,
@@ -93,7 +94,7 @@ class SPDXDocument(AlmasbomDocument):
 
         return doc
 
-    def write(self, output_file: str) -> None:
+    def write(self, output_file: Path) -> None:
         self.formatter.formatter.write_document_to_file(
             self.document,
             output_file,


### PR DESCRIPTION
Resolves: #58 

I followed these policies for this updates:
 - Filepaths specified by command line options are received as strings in argparse, but are initialized as Path objects when creating a Config class instance.
 - Within the program, all file paths are handled as Path objects.
 - When dealing with library APIs that require file paths to be passed as strings, each module is responsible for casting at the time of the call.