### PR TITLE
fix: correct arch in purl for source RPMs

### DIFF
--- a/alma_sbom/data/collectors/immudb/processor/apiver02.py
+++ b/alma_sbom/data/collectors/immudb/processor/apiver02.py
@@ -30,7 +30,7 @@ class DataProcessor02(DataProcessor):
             name = self.immudb_metadata.get('name'),
             version = self.immudb_metadata.get('version'),
             release = self.immudb_metadata.get('release'),
-            arch = self.immudb_metadata.get('arch'),
+            arch = self._resolve_arch(),
         )
         pkg_props, build_props, sbom_props = self._properties_from_immudb_info_about_package()
 
@@ -57,7 +57,7 @@ class DataProcessor02(DataProcessor):
             epoch = normalize_epoch(self.immudb_metadata['epoch']) if 'epoch' in self.immudb_metadata else None,
             version=self.immudb_metadata.get('version'),
             release=self.immudb_metadata.get('release'),
-            arch=self.immudb_metadata.get('arch'),
+            arch=self._resolve_arch(),
             buildhost=self.immudb_metadata.get('build_host'),
             sourcerpm=self.immudb_metadata.get('sourcerpm'),
             timestamp=self.immudb_info.get('timestamp'),

--- a/alma_sbom/data/collectors/immudb/processor/processor.py
+++ b/alma_sbom/data/collectors/immudb/processor/processor.py
@@ -13,6 +13,17 @@ class DataProcessor(ABC):
         self.immudb_metadata = immudb_metadata
         self.hash = hash
 
+    def _resolve_arch(self) -> str:
+        """Return corrected arch for source RPMs.
+
+        immudb metadata may store the builder machine arch (e.g. x86_64)
+        instead of 'src' for SRPMs.  Use build_arch and the Name field
+        as authoritative signals to fix this.
+        """
+        if self.immudb_metadata.get('build_arch') == 'src' or self.immudb_info.get('Name', '').endswith('.src.rpm'):
+            return 'src'
+        return self.immudb_metadata.get('arch')
+
     @abstractmethod
     def get_api_ver(self) -> str:
         pass


### PR DESCRIPTION
immudb metadata stores the builder machine architecture (e.g. x86_64) in the 'arch' field for source RPMs instead of 'src'. This causes the generated purl to contain arch=x86_64 instead of the correct arch=src, violating the purl specification for RPM packages.

Add _resolve_arch() to the base DataProcessor class that uses build_arch and the Name field as authoritative signals to detect source RPMs and return 'src' as the architecture.

Fixes: https://github.com/AlmaLinux/alma-sbom/issues/87